### PR TITLE
Add method to Browser to get logs [+semver: feature]

### DIFF
--- a/Aquality.Selenium/src/Aquality.Selenium/Browsers/Browser.cs
+++ b/Aquality.Selenium/src/Aquality.Selenium/Browsers/Browser.cs
@@ -8,6 +8,7 @@ using System.Drawing;
 using System.Reflection;
 using System;
 using Aquality.Selenium.Core.Waitings;
+using System.Collections.ObjectModel;
 
 namespace Aquality.Selenium.Browsers
 {
@@ -18,6 +19,7 @@ namespace Aquality.Selenium.Browsers
     {        
         private TimeSpan implicitWaitTimeout;
         private TimeSpan pageLoadTimeout;
+
         private readonly IBrowserProfile browserProfile;
         private readonly IConditionalWait conditionalWait;
 
@@ -239,6 +241,19 @@ namespace Aquality.Selenium.Browsers
         public byte[] GetScreenshot()
         {
             return Driver.GetScreenshot().AsByteArray;
+        }
+
+        /// <summary>
+        /// Gets logs from WebDriver.
+        /// </summary>
+        /// <param name="logKind">Type of logs <see cref="LogType"></param>
+        /// <returns>ReadOnlyCollection of log entries.</returns>
+        /// <remark>
+        /// Does not work on current version of Selenium WebDriver <see cref="https://github.com/SeleniumHQ/selenium/issues/7323">
+        /// </remark>
+        public ReadOnlyCollection<LogEntry> GetLogs(string logKind)
+        {
+            return Driver.Manage().Logs.GetLog(logKind);
         }
 
         /// <summary>

--- a/Aquality.Selenium/src/Aquality.Selenium/Browsers/Browser.cs
+++ b/Aquality.Selenium/src/Aquality.Selenium/Browsers/Browser.cs
@@ -249,7 +249,7 @@ namespace Aquality.Selenium.Browsers
         /// <param name="logKind">Type of logs <see cref="LogType"/></param>
         /// <returns>ReadOnlyCollection of log entries.</returns>
         /// <remark>
-        /// Does not work on current version of Selenium WebDriver <see cref="https://github.com/SeleniumHQ/selenium/issues/7323"/>
+        /// Does not work on current version of Selenium WebDriver. Issue: https://github.com/SeleniumHQ/selenium/issues/7323
         /// </remark>
         public ReadOnlyCollection<LogEntry> GetLogs(string logKind)
         {

--- a/Aquality.Selenium/src/Aquality.Selenium/Browsers/Browser.cs
+++ b/Aquality.Selenium/src/Aquality.Selenium/Browsers/Browser.cs
@@ -246,10 +246,10 @@ namespace Aquality.Selenium.Browsers
         /// <summary>
         /// Gets logs from WebDriver.
         /// </summary>
-        /// <param name="logKind">Type of logs <see cref="LogType"></param>
+        /// <param name="logKind">Type of logs <see cref="LogType"/></param>
         /// <returns>ReadOnlyCollection of log entries.</returns>
         /// <remark>
-        /// Does not work on current version of Selenium WebDriver <see cref="https://github.com/SeleniumHQ/selenium/issues/7323">
+        /// Does not work on current version of Selenium WebDriver <see cref="https://github.com/SeleniumHQ/selenium/issues/7323"/>
         /// </remark>
         public ReadOnlyCollection<LogEntry> GetLogs(string logKind)
         {

--- a/Aquality.Selenium/src/Aquality.Selenium/Browsers/BrowserTabNavigation.cs
+++ b/Aquality.Selenium/src/Aquality.Selenium/Browsers/BrowserTabNavigation.cs
@@ -62,10 +62,10 @@ namespace Aquality.Selenium.Browsers
             CloseAndSwitch(TabHandles.Last(), closeCurrent);
         }
 
-        public void SwitchToTab(string handle, bool closeCurrent = false)
+        public void SwitchToTab(string tabHandle, bool closeCurrent = false)
         {
-            Logger.Info("loc.browser.switch.to.tab.handle", handle);
-            CloseAndSwitch(handle, closeCurrent);
+            Logger.Info("loc.browser.switch.to.tab.handle", tabHandle);
+            CloseAndSwitch(tabHandle, closeCurrent);
         }
 
         public void SwitchToTab(int index, bool closeCurrent = false)

--- a/Aquality.Selenium/src/Aquality.Selenium/Browsers/IBrowserTabNavigation.cs
+++ b/Aquality.Selenium/src/Aquality.Selenium/Browsers/IBrowserTabNavigation.cs
@@ -22,7 +22,7 @@ namespace Aquality.Selenium.Browsers
         /// <summary>
         /// Switches to tab.
         /// </summary>
-        /// <param name="name">Tab handle.</param>
+        /// <param name="tabHandle">Tab handle.</param>
         /// <param name="closeCurrent">Close current tab if true and leave it otherwise.</param>
         void SwitchToTab(string tabHandle, bool closeCurrent = false);
 

--- a/Aquality.Selenium/src/Aquality.Selenium/Browsers/LocalBrowserFactory.cs
+++ b/Aquality.Selenium/src/Aquality.Selenium/Browsers/LocalBrowserFactory.cs
@@ -39,18 +39,18 @@ namespace Aquality.Selenium.Browsers
             {
                 case BrowserName.Chrome:
                     SetUpDriver(new ChromeConfig(), driverSettings);
-                    driver = new ChromeDriver(ChromeDriverService.CreateDefaultService(),
+                    driver = new ChromeDriver(ChromeDriverService.CreateDefaultService(), 
                         (ChromeOptions) driverSettings.DriverOptions, commandTimeout);
                     break;
                 case BrowserName.Firefox:
                     SetUpDriver(new FirefoxConfig(), driverSettings);
-                    FirefoxDriverService geckoService = FirefoxDriverService.CreateDefaultService();
+                    var geckoService = FirefoxDriverService.CreateDefaultService();
                     geckoService.Host = "::1";
                     driver = new FirefoxDriver(geckoService, (FirefoxOptions) driverSettings.DriverOptions, commandTimeout);
                     break;
                 case BrowserName.IExplorer:
                     SetUpDriver(new InternetExplorerConfig(), driverSettings);
-                    driver = new InternetExplorerDriver(InternetExplorerDriverService.CreateDefaultService(),
+                    driver = new InternetExplorerDriver(InternetExplorerDriverService.CreateDefaultService(), 
                         (InternetExplorerOptions) driverSettings.DriverOptions, commandTimeout);
                     break;
                 case BrowserName.Edge:

--- a/Aquality.Selenium/src/Aquality.Selenium/Resources/settings.json
+++ b/Aquality.Selenium/src/Aquality.Selenium/Resources/settings.json
@@ -8,7 +8,12 @@
     "chrome": {
       "webDriverVersion": "Latest",
       "capabilities": {
-        "enableVNC": true
+        "enableVNC": true,
+        "loggingPrefs": {
+          "driver": "INFO",
+          "server": "OFF",
+          "browser": "FINE"
+        }
       },
       "options": {
         "intl.accept_languages": "en",


### PR DESCRIPTION
resolves #174 

Added methods `GetLogs(string logKind)` to `Browser` which can be used in hooks to get and store browser logs to the desired place. 
Unfortunatelly, it doesn't work on the current version of Selenium WebDriver (https://github.com/SeleniumHQ/selenium/issues/7323).