### PR TITLE
Update Aquality.Selenium.Core library version.

### DIFF
--- a/Aquality.Selenium/src/Aquality.Selenium/Aquality.Selenium.csproj
+++ b/Aquality.Selenium/src/Aquality.Selenium/Aquality.Selenium.csproj
@@ -65,10 +65,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Aquality.Selenium.Core" Version="1.1.0" />
-    <PackageReference Include="NLog" Version="4.7.0" />
-    <PackageReference Include="Selenium.Support" Version="3.141.0" />
-    <PackageReference Include="Selenium.WebDriver" Version="3.141.0" />
+    <PackageReference Include="Aquality.Selenium.Core" Version="1.1.1" />
     <PackageReference Include="WebDriverManager" Version="2.9.1" />
   </ItemGroup>
 

--- a/Aquality.Selenium/src/Aquality.Selenium/Aquality.Selenium.xml
+++ b/Aquality.Selenium/src/Aquality.Selenium/Aquality.Selenium.xml
@@ -185,6 +185,16 @@
             </summary>
             <returns>Screenshot as byte array.</returns>
         </member>
+        <member name="M:Aquality.Selenium.Browsers.Browser.GetLogs(System.String)">
+            <summary>
+            Gets logs from WebDriver.
+            </summary>
+            <param name="logKind">Type of logs <see cref="T:OpenQA.Selenium.LogType"/></param>
+            <returns>ReadOnlyCollection of log entries.</returns>
+            <remark>
+            Does not work on current version of Selenium WebDriver. Issue: https://github.com/SeleniumHQ/selenium/issues/7323
+            </remark>
+        </member>
         <member name="M:Aquality.Selenium.Browsers.Browser.ScrollWindowBy(System.Int32,System.Int32)">
             <summary>
             Scrolls window by coordinates.
@@ -350,7 +360,7 @@
             <summary>
             Switches to tab.
             </summary>
-            <param name="name">Tab handle.</param>
+            <param name="tabHandle">Tab handle.</param>
             <param name="closeCurrent">Close current tab if true and leave it otherwise.</param>
         </member>
         <member name="M:Aquality.Selenium.Browsers.IBrowserTabNavigation.SwitchToTab(System.Int32,System.Boolean)">
@@ -761,6 +771,33 @@
             </summary>
             <returns>Dictionary where key is interface and value is its implementation.</returns>
         </member>
+        <member name="M:Aquality.Selenium.Elements.ElementFactory.GenerateXpathLocator(OpenQA.Selenium.By,OpenQA.Selenium.IWebElement,System.Int32)">
+            <summary>
+            Generates xpath locator for target element
+            </summary>
+            <param name="baseLocator">locator of parent element</param>
+            <param name="webElement">target element</param>
+            <param name="elementIndex">index of target element</param>
+            <returns>target element's locator</returns>
+        </member>
+        <member name="M:Aquality.Selenium.Elements.ElementFactory.IsLocatorSupportedForXPathExtraction(OpenQA.Selenium.By)">
+            <summary>
+            Defines is the locator can be transformed to xpath or not.
+            Current implementation works only with ByXPath.class and ByTagName locator types,
+            but you can implement your own for the specific WebDriver type.
+            </summary>
+            <param name="locator">locator to transform</param>
+            <returns>true if the locator can be transformed to xpath, false otherwise.</returns>
+        </member>
+        <member name="M:Aquality.Selenium.Elements.ElementFactory.ExtractXPathFromLocator(OpenQA.Selenium.By)">
+            <summary>
+            Extracts XPath from passed locator.
+            Current implementation works only with ByXPath.class and ByTagName locator types,
+            but you can implement your own for the specific WebDriver type.
+            </summary>
+            <param name="locator">locator to get xpath from.</param>
+            <returns>extracted XPath.</returns>
+        </member>
         <member name="T:Aquality.Selenium.Elements.HighlightState">
             <summary>
             Possible element hightlight states (on/off).
@@ -1088,24 +1125,43 @@
             <param name="locator">Unique locator of the form.</param>
             <param name="name">Name of the form.</param>
         </member>
+        <member name="P:Aquality.Selenium.Forms.Form.FormElement">
+            <summary>
+            Gets Form element defined by its locator and name.
+            Could be used to find child elements relative to form element.
+            </summary>
+        </member>
+        <member name="P:Aquality.Selenium.Forms.Form.Logger">
+            <summary>
+            Instance of logger <see cref="T:Aquality.Selenium.Core.Logging.Logger"/>
+            </summary>
+        </member>
+        <member name="P:Aquality.Selenium.Forms.Form.ElementFactory">
+            <summary>
+            Element factory <see cref="T:Aquality.Selenium.Elements.Interfaces.IElementFactory"/>
+            </summary>
+        </member>
         <member name="P:Aquality.Selenium.Forms.Form.Locator">
             <summary>
-            Locator of specified form.
+            Locator of the form.
             </summary>
         </member>
         <member name="P:Aquality.Selenium.Forms.Form.Name">
             <summary>
-            Name of specified form.
+            Name of the form.
             </summary>
         </member>
-        <!-- Badly formed XML comment ignored for member "P:Aquality.Selenium.Forms.Form.Logger" -->
-        <!-- Badly formed XML comment ignored for member "P:Aquality.Selenium.Forms.Form.ElementFactory" -->
         <member name="P:Aquality.Selenium.Forms.Form.IsDisplayed">
             <summary>
             Return form state for form locator
             </summary>
             <value>True - form is opened,
             False - form is not opened.</value>
+        </member>
+        <member name="P:Aquality.Selenium.Forms.Form.State">
+            <summary>
+            Provides ability to get form's state (whether it is displayed, exists or not) and respective waiting functions.
+            </summary>
         </member>
         <member name="P:Aquality.Selenium.Forms.Form.Size">
             <summary>
@@ -1118,6 +1174,29 @@
             </summary>
             <param name="x">horizontal coordinate</param>
             <param name="y">vertical coordinate</param>
+        </member>
+        <member name="M:Aquality.Selenium.Forms.Form.FindChildElement``1(OpenQA.Selenium.By,System.String,Aquality.Selenium.Core.Elements.ElementSupplier{``0},Aquality.Selenium.Core.Elements.ElementState)">
+            <summary>
+            Finds child element of current form by its locator.
+            </summary>
+            <typeparam name="T">Type of child element that has to implement IElement.</typeparam>
+            <param name="childLocator">Locator of child element relative to form.</param>
+            <param name="name">Child element name.</param>
+            <param name="supplier">Delegate that defines constructor of child element in case of custom element.</param>
+            <param name="state">Child element state.</param>
+            <returns>Instance of child element.</returns>
+        </member>
+        <member name="M:Aquality.Selenium.Forms.Form.FindChildElements``1(OpenQA.Selenium.By,System.String,Aquality.Selenium.Core.Elements.ElementSupplier{``0},Aquality.Selenium.Core.Elements.ElementsCount,Aquality.Selenium.Core.Elements.ElementState)">
+            <summary>
+            Finds child elements of current form by their locator.
+            </summary>
+            <typeparam name="T">Type of child elements that has to implement IElement.</typeparam>
+            <param name="childLocator">Locator of child elements relative to form.</param>
+            <param name="name">Child elements name.</param>
+            <param name="supplier">Delegate that defines constructor of child element in case of custom element type.</param>
+            <param name="expectedCount">Expected number of elements that have to be found (zero, more then zero, any).</param>
+            <param name="state">Child elements state.</param>
+            <returns>List of child elements.</returns>
         </member>
     </members>
 </doc>

--- a/Aquality.Selenium/src/Aquality.Selenium/Configurations/WebDriverSettings/DriverSettings.cs
+++ b/Aquality.Selenium/src/Aquality.Selenium/Configurations/WebDriverSettings/DriverSettings.cs
@@ -50,9 +50,9 @@ namespace Aquality.Selenium.Configurations.WebDriverSettings
 
         public abstract string DownloadDirCapabilityKey { get; }
 
-        protected IDictionary<string, object> BrowserCapabilities => SettingsFile.GetValueOrNew<Dictionary<string, object>>($"{DriverSettingsPath}.capabilities");
+        protected IReadOnlyDictionary<string, object> BrowserCapabilities => SettingsFile.GetValueDictionaryOrEmpty<object>($"{DriverSettingsPath}.capabilities");
 
-        protected IDictionary<string, object> BrowserOptions => SettingsFile.GetValueOrNew<Dictionary<string, object>>($"{DriverSettingsPath}.options");
+        protected IReadOnlyDictionary<string, object> BrowserOptions => SettingsFile.GetValueDictionaryOrEmpty<object>($"{DriverSettingsPath}.options");
 
         protected IReadOnlyList<string> BrowserStartArguments => SettingsFile.GetValueListOrEmpty<string>($"{DriverSettingsPath}.startArguments");
 

--- a/Aquality.Selenium/src/Aquality.Selenium/Forms/Form.cs
+++ b/Aquality.Selenium/src/Aquality.Selenium/Forms/Form.cs
@@ -1,10 +1,12 @@
-﻿using Aquality.Selenium.Elements.Interfaces;
-using OpenQA.Selenium;
-using System.Drawing;
-using Aquality.Selenium.Browsers;
-using Aquality.Selenium.Core.Localization;
-using Aquality.Selenium.Core.Elements;
+﻿using System;
 using System.Collections.Generic;
+using System.Drawing;
+using OpenQA.Selenium;
+using Aquality.Selenium.Core.Elements;
+using Aquality.Selenium.Core.Logging;
+using Aquality.Selenium.Browsers;
+using Aquality.Selenium.Elements.Interfaces;
+using IElementStateProvider = Aquality.Selenium.Core.Elements.Interfaces.IElementStateProvider;
 
 namespace Aquality.Selenium.Forms
 {
@@ -13,6 +15,7 @@ namespace Aquality.Selenium.Forms
     /// </summary>
     public abstract class Form
     {
+        private readonly ILabel formLabel;
         /// <summary>
         /// Constructor with parameters.
         /// </summary>
@@ -22,29 +25,32 @@ namespace Aquality.Selenium.Forms
         {
             Locator = locator;
             Name = name;
+            formLabel = ElementFactory.GetLabel(Locator, Name);
         }
 
-        private ILabel FormLabel => ElementFactory.GetLabel(Locator, Name);
-
         /// <summary>
-        /// Instance of logger <see cref="Logging.Logger">
+        /// Gets Form element defined by its locator and name.
+        /// Could be used to find child elements relative to form element.
         /// </summary>
-        /// <value>Logger instance.</value>
-        protected ILocalizedLogger Logger => AqualityServices.LocalizedLogger;
+        protected IElement FormElement => formLabel;
 
         /// <summary>
-        /// Element factory <see cref="IElementFactory">
+        /// Instance of logger <see cref="Core.Logging.Logger"/>
         /// </summary>
-        /// <value>Element factory.</value>
-        protected IElementFactory ElementFactory => AqualityServices.Get<IElementFactory>();
+        protected static Logger Logger => AqualityServices.Logger;
 
         /// <summary>
-        /// Locator of specified form.
+        /// Element factory <see cref="IElementFactory"/>
+        /// </summary>
+        protected static IElementFactory ElementFactory => AqualityServices.Get<IElementFactory>();
+
+        /// <summary>
+        /// Locator of the form.
         /// </summary>
         public By Locator { get; }
 
         /// <summary>
-        /// Name of specified form.
+        /// Name of the form.
         /// </summary>
         public string Name { get; }
 
@@ -53,12 +59,18 @@ namespace Aquality.Selenium.Forms
         /// </summary>
         /// <value>True - form is opened,
         /// False - form is not opened.</value>
-        public bool IsDisplayed => FormLabel.State.WaitForDisplayed();
+        [Obsolete("This property will be removed in the future release. Use State.WaitForDisplayed() if needed")] 
+        public bool IsDisplayed => FormElement.State.WaitForDisplayed();
+
+        /// <summary>
+        /// Provides ability to get form's state (whether it is displayed, exists or not) and respective waiting functions.
+        /// </summary>
+        public IElementStateProvider State => FormElement.State;
 
         /// <summary>
         /// Gets size of form element defined by its locator.
         /// </summary>
-        public Size Size => FormLabel.GetElement().Size;
+        public Size Size => FormElement.GetElement().Size;
 
         /// <summary>
         /// Scroll form without scrolling entire page
@@ -67,7 +79,7 @@ namespace Aquality.Selenium.Forms
         /// <param name="y">vertical coordinate</param>
         public void ScrollBy(int x, int y)
         {
-            FormLabel.JsActions.ScrollBy(x, y);
+            FormElement.JsActions.ScrollBy(x, y);
         }
 
         /// <summary>
@@ -79,9 +91,11 @@ namespace Aquality.Selenium.Forms
         /// <param name="supplier">Delegate that defines constructor of child element in case of custom element.</param>
         /// <param name="state">Child element state.</param>
         /// <returns>Instance of child element.</returns>
-        protected T FindChildElement<T>(By childLocator, string name = null, ElementSupplier<T> supplier = null, ElementState state = ElementState.Displayed) where T : Core.Elements.Interfaces.IElement
+        [Obsolete("This method will be removed in the future release. Use FormElement property methods to find child element")]
+        protected T FindChildElement<T>(By childLocator, string name = null, ElementSupplier<T> supplier = null, ElementState state = ElementState.Displayed) 
+            where T : IElement
         {
-            return FormLabel.FindChildElement(childLocator, name, supplier, state);
+            return FormElement.FindChildElement(childLocator, name, supplier, state);
         }
 
         /// <summary>
@@ -94,9 +108,11 @@ namespace Aquality.Selenium.Forms
         /// <param name="expectedCount">Expected number of elements that have to be found (zero, more then zero, any).</param>
         /// <param name="state">Child elements state.</param>
         /// <returns>List of child elements.</returns>
-        protected IList<T> FindChildElements<T>(By childLocator, string name = null, ElementSupplier<T> supplier = null, ElementsCount expectedCount = ElementsCount.Any, ElementState state = ElementState.Displayed) where T : Core.Elements.Interfaces.IElement
+        [Obsolete("This method will be removed in the future release. Use FormElement property methods to find child elements")]
+        protected IList<T> FindChildElements<T>(By childLocator, string name = null, ElementSupplier<T> supplier = null, ElementsCount expectedCount = ElementsCount.Any, ElementState state = ElementState.Displayed) 
+            where T : IElement
         {
-            return FormLabel.FindChildElements(childLocator, name, supplier, expectedCount, state);
+            return FormElement.FindChildElements(childLocator, name, supplier, expectedCount, state);
         }
     }
 }

--- a/Aquality.Selenium/tests/Aquality.Selenium.Tests/Integration/TestApp/AutomationPractice/Forms/ProductTabContentForm.cs
+++ b/Aquality.Selenium/tests/Aquality.Selenium.Tests/Integration/TestApp/AutomationPractice/Forms/ProductTabContentForm.cs
@@ -45,7 +45,7 @@ namespace Aquality.Selenium.Tests.Integration.TestApp.AutomationPractice.Forms
 
         public Label GetChildElementByNonXPath(ElementState state)
         {
-            return FindChildElement<Label>(BestSellersById, state: state);
+            return FormElement.FindChildElement<Label>(BestSellersById, state: state);
         }
 
         public IList<Label> GetListElementsByDottedXPath(ElementState state, ElementsCount count)
@@ -55,7 +55,7 @@ namespace Aquality.Selenium.Tests.Integration.TestApp.AutomationPractice.Forms
 
         public IList<Label> GetChildElementsByDottedXPath(ElementState state, ElementsCount count)
         {
-            return FindChildElements<Label>(DottedXPath, state: state, expectedCount: count);
+            return FormElement.FindChildElements<Label>(DottedXPath, state: state, expectedCount: count);
         }
     }
 }

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -28,6 +28,8 @@ stages:
 
     - task: DotNetCoreCLI@2
       displayName: 'Build solution'
+      env: 
+        MSBUILDSINGLELOADCONTEXT: 1  # https://github.com/SpecFlowOSS/SpecFlow/issues/1912
       inputs:
         command: 'build'
         projects: Aquality.Selenium/Aquality.Selenium.sln


### PR DESCRIPTION
- Allow overriding of browser capabilities and options via environment variables.
- Remove core library dependencies duplication.
- Add documentation to form methods.
- Mark some form methods and properties as obsolete with explanation what to use instead.
- Replace LocalizationLogger with Logger property in form.
- Make ElementFactory property in Form static in to make it possible to be used during the field initialization.