### PR TITLE
Add  "unhandledPromptBehavior" capability handling

### DIFF
--- a/Aquality.Selenium/src/Aquality.Selenium/Configurations/WebDriverSettings/ChromeSettings.cs
+++ b/Aquality.Selenium/src/Aquality.Selenium/Configurations/WebDriverSettings/ChromeSettings.cs
@@ -30,7 +30,7 @@ namespace Aquality.Selenium.Configurations.WebDriverSettings
                 SetChromePrefs(options);
                 SetCapabilities(options, (name, value) => options.AddAdditionalCapability(name, value, isGlobalCapability: true));
                 SetChromeArguments(options);
-                SetPageLoadStratergy(options);
+                SetPageLoadStrategy(options);
                 return options;
             }
         }

--- a/Aquality.Selenium/src/Aquality.Selenium/Configurations/WebDriverSettings/DriverSettings.cs
+++ b/Aquality.Selenium/src/Aquality.Selenium/Configurations/WebDriverSettings/DriverSettings.cs
@@ -70,7 +70,7 @@ namespace Aquality.Selenium.Configurations.WebDriverSettings
                             args: string.Join(",", capabilities.Select(cap => $"{Environment.NewLine}{cap.Key}: {cap.Value}")));
                     }
                 }
-                
+
                 return capabilities;
             }
         }
@@ -81,14 +81,14 @@ namespace Aquality.Selenium.Configurations.WebDriverSettings
             {
                 if (options == null)
                 {
-                    options = SettingsFile.GetValueDictionaryOrEmpty<object>($"{DriverSettingsPath}.{nameof(options)}"); 
+                    options = SettingsFile.GetValueDictionaryOrEmpty<object>($"{DriverSettingsPath}.{nameof(options)}");
                     if (options.Any())
                     {
                         AqualityServices.LocalizedLogger.Debug("loc.browser.options",
                             args: string.Join(",", options.Select(opt => $"{Environment.NewLine}{opt.Key}: {opt.Value}")));
                     }
-                }                
-                
+                }
+
                 return options;
             }
         }
@@ -110,14 +110,11 @@ namespace Aquality.Selenium.Configurations.WebDriverSettings
             }
         }
 
-        private string DriverSettingsPath => $".driverSettings.{BrowserName.ToString().ToLowerInvariant()}";        
+        private string DriverSettingsPath => $".driverSettings.{BrowserName.ToString().ToLowerInvariant()}";
 
         protected abstract BrowserName BrowserName { get; }
 
-        protected virtual IDictionary<string, Action<DriverOptions, object>> KnownCapabilitySetters => new Dictionary<string, Action<DriverOptions, object>>
-        {
-            { CapabilityType.UnhandledPromptBehavior, (options, value) => options.UnhandledPromptBehavior = value.ToEnum<UnhandledPromptBehavior>() }
-        };
+        protected virtual IDictionary<string, Action<DriverOptions, object>> KnownCapabilitySetters => new Dictionary<string, Action<DriverOptions, object>>();
 
         protected void SetPageLoadStrategy(DriverOptions options)
         {
@@ -132,10 +129,10 @@ namespace Aquality.Selenium.Configurations.WebDriverSettings
                 {
                     var defaultAddCapabilityMethod = addCapabilityMethod ?? options.AddAdditionalCapability;
                     defaultAddCapabilityMethod(capability.Key, capability.Value);
-                } 
+                }
                 catch (ArgumentException exception)
                 {
-                    if(exception.Message.StartsWith("There is already an option"))
+                    if (exception.Message.StartsWith("There is already an option"))
                     {
                         SetKnownProperty(options, capability, exception);
                     }
@@ -156,7 +153,7 @@ namespace Aquality.Selenium.Configurations.WebDriverSettings
             else
             {
                 SetOptionByPropertyName(options, capability, exception);
-            }            
+            }
         }
 
         protected void SetOptionsByPropertyNames(DriverOptions options)
@@ -174,7 +171,41 @@ namespace Aquality.Selenium.Configurations.WebDriverSettings
                             .GetProperties()
                             .FirstOrDefault(property => IsPropertyNameMatchOption(property.Name, option.Key) && property.CanWrite)
                             ?? throw exception;
-            optionProperty.SetValue(options, option.Value);
+            var propertyType = optionProperty.PropertyType;
+            var valueToSet = IsEnumValue(propertyType, option.Value)
+                ? ParseEnumValue(propertyType, option.Value)
+                : option.Value;
+            optionProperty.SetValue(options, valueToSet);
+        }
+
+        private object ParseEnumValue(Type propertyType, object optionValue)
+        {
+            return optionValue is string
+                ? Enum.Parse(propertyType, optionValue.ToString(), ignoreCase: true)
+                : Enum.ToObject(propertyType, Convert.ChangeType(optionValue, Enum.GetUnderlyingType(propertyType)));
+        }
+
+        private bool IsEnumValue(Type propertyType, object optionValue)
+        {
+            var valueAsString = optionValue.ToString();
+            if (!propertyType.IsEnum || string.IsNullOrEmpty(valueAsString))
+            {
+                return false;
+            }
+            var normalizedValue = char.ToUpper(valueAsString[0]) +
+                (valueAsString.Length > 1 ? valueAsString.Substring(1) : string.Empty);
+            return propertyType.IsEnumDefined(normalizedValue)
+                || propertyType.IsEnumDefined(valueAsString)
+                || (IsValueOfIntegralNumericType(optionValue)
+                    && propertyType.IsEnumDefined(Convert.ChangeType(optionValue, Enum.GetUnderlyingType(propertyType))));
+        }
+
+        private bool IsValueOfIntegralNumericType(object value)
+        {
+            return value is byte || value is sbyte
+                || value is ushort || value is short
+                || value is uint || value is int
+                || value is ulong || value is long;
         }
 
         private bool IsPropertyNameMatchOption(string propertyName, string optionKey)

--- a/Aquality.Selenium/src/Aquality.Selenium/Configurations/WebDriverSettings/DriverSettings.cs
+++ b/Aquality.Selenium/src/Aquality.Selenium/Configurations/WebDriverSettings/DriverSettings.cs
@@ -38,8 +38,6 @@ namespace Aquality.Selenium.Configurations.WebDriverSettings
 
         public PageLoadStrategy PageLoadStrategy => SettingsFile.GetValueOrDefault($"{DriverSettingsPath}.pageLoadStrategy", PageLoadStrategy.Normal).ToEnum<PageLoadStrategy>();
 
-        public UnhandledPromptBehavior UnhandledPromptBehavior => SettingsFile.GetValueOrDefault($"{DriverSettingsPath}.unhandledPromptBehavior", UnhandledPromptBehavior.Ignore).ToEnum<UnhandledPromptBehavior>();
-
         public virtual string DownloadDir
         {
             get

--- a/Aquality.Selenium/src/Aquality.Selenium/Configurations/WebDriverSettings/DriverSettings.cs
+++ b/Aquality.Selenium/src/Aquality.Selenium/Configurations/WebDriverSettings/DriverSettings.cs
@@ -2,7 +2,6 @@
 using Aquality.Selenium.Core.Configurations;
 using Aquality.Selenium.Core.Utilities;
 using OpenQA.Selenium;
-using OpenQA.Selenium.Remote;
 using System;
 using System.Collections.Generic;
 using System.IO;

--- a/Aquality.Selenium/src/Aquality.Selenium/Configurations/WebDriverSettings/DriverSettings.cs
+++ b/Aquality.Selenium/src/Aquality.Selenium/Configurations/WebDriverSettings/DriverSettings.cs
@@ -2,6 +2,7 @@
 using Aquality.Selenium.Core.Configurations;
 using Aquality.Selenium.Core.Utilities;
 using OpenQA.Selenium;
+using OpenQA.Selenium.Remote;
 using System;
 using System.Collections.Generic;
 using System.IO;
@@ -37,6 +38,8 @@ namespace Aquality.Selenium.Configurations.WebDriverSettings
         public abstract DriverOptions DriverOptions { get; }
 
         public PageLoadStrategy PageLoadStrategy => SettingsFile.GetValueOrDefault($"{DriverSettingsPath}.pageLoadStrategy", PageLoadStrategy.Normal).ToEnum<PageLoadStrategy>();
+
+        public UnhandledPromptBehavior UnhandledPromptBehavior => SettingsFile.GetValueOrDefault($"{DriverSettingsPath}.unhandledPromptBehavior", UnhandledPromptBehavior.Ignore).ToEnum<UnhandledPromptBehavior>();
 
         public virtual string DownloadDir
         {
@@ -111,9 +114,12 @@ namespace Aquality.Selenium.Configurations.WebDriverSettings
 
         protected abstract BrowserName BrowserName { get; }
 
-        protected virtual IDictionary<string, Action<DriverOptions, object>> KnownCapabilitySetters => new Dictionary<string, Action<DriverOptions, object>>();
+        protected virtual IDictionary<string, Action<DriverOptions, object>> KnownCapabilitySetters => new Dictionary<string, Action<DriverOptions, object>>
+        {
+            { CapabilityType.UnhandledPromptBehavior, (options, value) => options.UnhandledPromptBehavior = value.ToEnum<UnhandledPromptBehavior>() }
+        };
 
-        protected void SetPageLoadStratergy(DriverOptions options)
+        protected void SetPageLoadStrategy(DriverOptions options)
         {
             options.PageLoadStrategy = PageLoadStrategy;
         }

--- a/Aquality.Selenium/src/Aquality.Selenium/Configurations/WebDriverSettings/EdgeChromiumSettings.cs
+++ b/Aquality.Selenium/src/Aquality.Selenium/Configurations/WebDriverSettings/EdgeChromiumSettings.cs
@@ -33,7 +33,7 @@ namespace Aquality.Selenium.Configurations.WebDriverSettings
                 SetEdgeChromiumPrefs(options);
                 SetCapabilities(options, (name, value) => options.AddAdditionalCapability(name, value, isGlobalCapability: true));
                 SetEdgeChromiumArguments(options);
-                SetPageLoadStratergy(options);
+                SetPageLoadStrategy(options);
                 return options;
             }
         }

--- a/Aquality.Selenium/src/Aquality.Selenium/Configurations/WebDriverSettings/EdgeSettings.cs
+++ b/Aquality.Selenium/src/Aquality.Selenium/Configurations/WebDriverSettings/EdgeSettings.cs
@@ -28,7 +28,7 @@ namespace Aquality.Selenium.Configurations.WebDriverSettings
                 var options = new EdgeOptions();
                 SetCapabilities(options);
                 SetOptionsByPropertyNames(options);
-                SetPageLoadStratergy(options);
+                SetPageLoadStrategy(options);
                 return options;
             }
         }

--- a/Aquality.Selenium/src/Aquality.Selenium/Configurations/WebDriverSettings/FirefoxSettings.cs
+++ b/Aquality.Selenium/src/Aquality.Selenium/Configurations/WebDriverSettings/FirefoxSettings.cs
@@ -3,6 +3,7 @@ using Aquality.Selenium.Core.Configurations;
 using Aquality.Selenium.Core.Utilities;
 using OpenQA.Selenium;
 using OpenQA.Selenium.Firefox;
+using OpenQA.Selenium.Remote;
 using System;
 using System.Collections.Generic;
 
@@ -29,7 +30,8 @@ namespace Aquality.Selenium.Configurations.WebDriverSettings
             { "firefox_binary", (options, value) => ((FirefoxOptions) options).BrowserExecutableLocation = value.ToString() },
             { "firefox_profile", (options, value) => ((FirefoxOptions) options).Profile = new FirefoxProfileManager().GetProfile(value.ToString()) },
             { "log", (options, value) => ((FirefoxOptions) options).LogLevel = value.ToEnum<FirefoxDriverLogLevel>() },
-            { "marionette", (options, value) => ((FirefoxOptions) options).UseLegacyImplementation = (bool) value }
+            { "marionette", (options, value) => ((FirefoxOptions) options).UseLegacyImplementation = (bool) value },
+            { CapabilityType.UnhandledPromptBehavior, (options, value) => options.UnhandledPromptBehavior = value.ToEnum<UnhandledPromptBehavior>() }
         };
 
         public override DriverOptions DriverOptions
@@ -40,7 +42,7 @@ namespace Aquality.Selenium.Configurations.WebDriverSettings
                 SetCapabilities(options, (name, value) => options.AddAdditionalCapability(name, value, isGlobalCapability: true));
                 SetFirefoxPrefs(options);
                 SetFirefoxArguments(options);
-                SetPageLoadStratergy(options);
+                SetPageLoadStrategy(options);
                 return options;
             }
         }
@@ -54,21 +56,21 @@ namespace Aquality.Selenium.Configurations.WebDriverSettings
                 {
                     options.SetPreference(option.Key, DownloadDir);
                 }
-                else if (value is bool)
+                else if (value is bool boolean)
                 {
-                    options.SetPreference(option.Key, (bool) value);
+                    options.SetPreference(option.Key, boolean);
                 }
-                else if (value is int)
+                else if (value is int @int)
                 {
-                    options.SetPreference(option.Key, (int) value);
+                    options.SetPreference(option.Key, @int);
                 }
-                else if (value is long)
+                else if (value is long @long)
                 {
-                    options.SetPreference(option.Key, (long)value);
+                    options.SetPreference(option.Key, @long);
                 }
-                else if (value is float)
+                else if (value is float @float)
                 {
-                    options.SetPreference(option.Key, (float) value);
+                    options.SetPreference(option.Key, @float);
                 }
                 else if (value is string)
                 {

--- a/Aquality.Selenium/src/Aquality.Selenium/Configurations/WebDriverSettings/FirefoxSettings.cs
+++ b/Aquality.Selenium/src/Aquality.Selenium/Configurations/WebDriverSettings/FirefoxSettings.cs
@@ -30,8 +30,7 @@ namespace Aquality.Selenium.Configurations.WebDriverSettings
             { "firefox_binary", (options, value) => ((FirefoxOptions) options).BrowserExecutableLocation = value.ToString() },
             { "firefox_profile", (options, value) => ((FirefoxOptions) options).Profile = new FirefoxProfileManager().GetProfile(value.ToString()) },
             { "log", (options, value) => ((FirefoxOptions) options).LogLevel = value.ToEnum<FirefoxDriverLogLevel>() },
-            { "marionette", (options, value) => ((FirefoxOptions) options).UseLegacyImplementation = (bool) value },
-            { CapabilityType.UnhandledPromptBehavior, (options, value) => options.UnhandledPromptBehavior = value.ToEnum<UnhandledPromptBehavior>() }
+            { "marionette", (options, value) => ((FirefoxOptions) options).UseLegacyImplementation = (bool) value }
         };
 
         public override DriverOptions DriverOptions

--- a/Aquality.Selenium/src/Aquality.Selenium/Configurations/WebDriverSettings/FirefoxSettings.cs
+++ b/Aquality.Selenium/src/Aquality.Selenium/Configurations/WebDriverSettings/FirefoxSettings.cs
@@ -3,7 +3,6 @@ using Aquality.Selenium.Core.Configurations;
 using Aquality.Selenium.Core.Utilities;
 using OpenQA.Selenium;
 using OpenQA.Selenium.Firefox;
-using OpenQA.Selenium.Remote;
 using System;
 using System.Collections.Generic;
 

--- a/Aquality.Selenium/src/Aquality.Selenium/Configurations/WebDriverSettings/InternetExplorerSettings.cs
+++ b/Aquality.Selenium/src/Aquality.Selenium/Configurations/WebDriverSettings/InternetExplorerSettings.cs
@@ -29,7 +29,7 @@ namespace Aquality.Selenium.Configurations.WebDriverSettings
             { "ignoreProtectedModeSettings", (options, value) => ((InternetExplorerOptions) options).IntroduceInstabilityByIgnoringProtectedModeSettings = (bool) value },
             { "ignoreZoomSetting", (options, value) => ((InternetExplorerOptions) options).IgnoreZoomLevel = (bool) value },
             { CapabilityType.HasNativeEvents, (options, value) => ((InternetExplorerOptions) options).EnableNativeEvents = (bool) value },
-            { CapabilityType.UnexpectedAlertBehavior, (options, value) => ((InternetExplorerOptions) options).UnhandledPromptBehavior = value.ToEnum<UnhandledPromptBehavior>() },
+            { CapabilityType.UnhandledPromptBehavior, (options, value) => ((InternetExplorerOptions) options).UnhandledPromptBehavior = value.ToEnum<UnhandledPromptBehavior>() },
             { "ie.browserCommandLineSwitches", (options, value) => ((InternetExplorerOptions) options).BrowserCommandLineArguments = value.ToString() },
             { "elementScrollBehavior", (options, value) => ((InternetExplorerOptions) options).ElementScrollBehavior = value.ToEnum<InternetExplorerElementScrollBehavior>() }
         };
@@ -41,7 +41,7 @@ namespace Aquality.Selenium.Configurations.WebDriverSettings
                 var options = new InternetExplorerOptions();
                 SetCapabilities(options);
                 SetOptionsByPropertyNames(options);
-                SetPageLoadStratergy(options);
+                SetPageLoadStrategy(options);
                 options.BrowserCommandLineArguments = string.Join(" ", BrowserStartArguments);
                 return options;
             }

--- a/Aquality.Selenium/src/Aquality.Selenium/Configurations/WebDriverSettings/InternetExplorerSettings.cs
+++ b/Aquality.Selenium/src/Aquality.Selenium/Configurations/WebDriverSettings/InternetExplorerSettings.cs
@@ -29,9 +29,7 @@ namespace Aquality.Selenium.Configurations.WebDriverSettings
             { "ignoreProtectedModeSettings", (options, value) => ((InternetExplorerOptions) options).IntroduceInstabilityByIgnoringProtectedModeSettings = (bool) value },
             { "ignoreZoomSetting", (options, value) => ((InternetExplorerOptions) options).IgnoreZoomLevel = (bool) value },
             { CapabilityType.HasNativeEvents, (options, value) => ((InternetExplorerOptions) options).EnableNativeEvents = (bool) value },
-            { CapabilityType.UnhandledPromptBehavior, (options, value) => ((InternetExplorerOptions) options).UnhandledPromptBehavior = value.ToEnum<UnhandledPromptBehavior>() },
-            { "ie.browserCommandLineSwitches", (options, value) => ((InternetExplorerOptions) options).BrowserCommandLineArguments = value.ToString() },
-            { "elementScrollBehavior", (options, value) => ((InternetExplorerOptions) options).ElementScrollBehavior = value.ToEnum<InternetExplorerElementScrollBehavior>() }
+            { "ie.browserCommandLineSwitches", (options, value) => ((InternetExplorerOptions) options).BrowserCommandLineArguments = value.ToString() }
         };
 
         public override DriverOptions DriverOptions

--- a/Aquality.Selenium/src/Aquality.Selenium/Configurations/WebDriverSettings/InternetExplorerSettings.cs
+++ b/Aquality.Selenium/src/Aquality.Selenium/Configurations/WebDriverSettings/InternetExplorerSettings.cs
@@ -2,7 +2,6 @@
 using System.Collections.Generic;
 using Aquality.Selenium.Browsers;
 using Aquality.Selenium.Core.Configurations;
-using Aquality.Selenium.Core.Utilities;
 using OpenQA.Selenium;
 using OpenQA.Selenium.IE;
 using OpenQA.Selenium.Remote;

--- a/Aquality.Selenium/src/Aquality.Selenium/Configurations/WebDriverSettings/SafariSettings.cs
+++ b/Aquality.Selenium/src/Aquality.Selenium/Configurations/WebDriverSettings/SafariSettings.cs
@@ -27,7 +27,7 @@ namespace Aquality.Selenium.Configurations.WebDriverSettings
                 var options = new SafariOptions();
                 SetCapabilities(options);
                 SetOptionsByPropertyNames(options);
-                SetPageLoadStratergy(options);
+                SetPageLoadStrategy(options);
                 return options;
             }
         }

--- a/Aquality.Selenium/src/Aquality.Selenium/Resources/settings.json
+++ b/Aquality.Selenium/src/Aquality.Selenium/Resources/settings.json
@@ -13,7 +13,8 @@
           "driver": "INFO",
           "server": "OFF",
           "browser": "FINE"
-        }
+        },
+        "unhandledPromptBehavior": "default"
       },
       "options": {
         "intl.accept_languages": "en",
@@ -29,7 +30,8 @@
     "firefox": {
       "webDriverVersion": "Latest",
       "capabilities": {
-        "enableVNC": true
+        "enableVNC": true,
+        "unhandledPromptBehavior": "default"
       },
       "options": {
         "intl.accept_languages": "en",
@@ -52,7 +54,8 @@
       "webDriverVersion": "Latest",
       "systemArchitecture": "X32",
       "capabilities": {
-        "ignoreProtectedModeSettings": true
+        "ignoreProtectedModeSettings": true,
+        "unhandledPromptBehavior": "default"
       },
       "options": {
       },
@@ -61,6 +64,7 @@
     "edge": {
       "systemArchitecture": "X32",
       "capabilities": {
+        "unhandledPromptBehavior": "default"
       },
       "options": {
       },

--- a/Aquality.Selenium/tests/Aquality.Selenium.Tests/Integration/AlertTests.cs
+++ b/Aquality.Selenium/tests/Aquality.Selenium.Tests/Integration/AlertTests.cs
@@ -32,6 +32,28 @@ namespace Aquality.Selenium.Tests.Integration
         }
 
         [Test]
+        public void Should_BePossibleTo_AcceptConfirmationAlert_InWaitFor()
+        {
+            alertsForm.JsConfirmButton.Click();
+            AqualityServices.ConditionalWait.WaitFor(driver =>
+            {
+                try
+                {
+                    AqualityServices.Logger.Debug($"Current url: {driver.Url}");
+                    return false;
+                }
+                catch (UnhandledAlertException e)
+                {
+                    AqualityServices.Logger.Debug($"Alert appeared: {e.Message}");
+                    AqualityServices.Browser.HandleAlert(AlertAction.Accept);
+                    return true;
+                }
+                
+            });
+            Assert.AreEqual("You clicked: Ok", alertsForm.ResultLabel.GetText());
+        }
+
+        [Test]
         public void Should_BePossibleTo_DeclineConfirmationAlert()
         {
             alertsForm.JsConfirmButton.Click();

--- a/Aquality.Selenium/tests/Aquality.Selenium.Tests/Resources/settings.azure.json
+++ b/Aquality.Selenium/tests/Aquality.Selenium.Tests/Resources/settings.azure.json
@@ -8,7 +8,8 @@
     "chrome": {
       "webDriverVersion": "MatchingBrowser",
       "capabilities": {
-        "enableVNC": true
+        "enableVNC": true,
+        "unhandledPromptBehavior": "ignore"
       },
       "options": {
         "intl.accept_languages": "en",

--- a/Aquality.Selenium/tests/Aquality.Selenium.Tests/Resources/settings.json
+++ b/Aquality.Selenium/tests/Aquality.Selenium.Tests/Resources/settings.json
@@ -8,7 +8,8 @@
     "chrome": {
       "webDriverVersion": "MatchingBrowser",
       "capabilities": {
-        "enableVNC": true
+        "enableVNC": true,
+        "unhandledPromptBehavior": "ignore"
       },
       "options": {
         "intl.accept_languages": "en",
@@ -24,7 +25,8 @@
       "webDriverVersion": "Latest",
       "systemArchitecture": "X64",
       "capabilities": {
-        "enableVNC": true
+        "enableVNC": true,
+        "unhandledPromptBehavior": "ignore"
       },
       "options": {
         "intl.accept_languages": "en",
@@ -49,12 +51,14 @@
       "capabilities": {
         "ignoreProtectedModeSettings": true,
         "requireWindowFocus": false,
-        "elementScrollBehavior": 2
+        "elementScrollBehavior": 2,
+        "unhandledPromptBehavior": "ignore"
       }
     },
     "edge": {
       "systemArchitecture": "X64",
       "capabilities": {
+        "unhandledPromptBehavior": "ignore"
       },
       "options": {
       },
@@ -63,7 +67,8 @@
     "edgechromium": {
       "webDriverVersion": "82.0.458.0",
       "capabilities": {
-        "enableVNC": true
+        "enableVNC": true,
+        "unhandledPromptBehavior": "ignore"
       },
       "options": {
         "intl.accept_languages": "en",


### PR DESCRIPTION
Closes #195 
Related to https://github.com/SeleniumHQ/selenium/issues/7356
> Chrome 75 swapped to W3C mode by default. As such, this is behaving as specified in the WebDriver spec - https://w3c.github.io/webdriver/#capabilities - where the default behavior is defined to be "dismiss and notify". You should be able to get the previous behavior by setting the unhandledPromptBehavior capability to 'ignore' in your driver configuration - https://w3c.github.io/webdriver/#user-prompts.