### PR TITLE
Update core package version to fix type conversion for object primitive type

### DIFF
--- a/Aquality.Selenium/src/Aquality.Selenium/Aquality.Selenium.csproj
+++ b/Aquality.Selenium/src/Aquality.Selenium/Aquality.Selenium.csproj
@@ -69,8 +69,8 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Edge.SeleniumTools" Version="3.141.2" />
-    <PackageReference Include="Aquality.Selenium.Core" Version="1.2.2" />
-    <PackageReference Include="WebDriverManager" Version="2.11.0" />
+    <PackageReference Include="Aquality.Selenium.Core" Version="1.3.1" />
+    <PackageReference Include="WebDriverManager" Version="2.11.1" />
   </ItemGroup>
 
 </Project>

--- a/Aquality.Selenium/tests/Aquality.Selenium.Tests/Aquality.Selenium.Tests.csproj
+++ b/Aquality.Selenium/tests/Aquality.Selenium.Tests/Aquality.Selenium.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>net5.0</TargetFramework>
 
     <IsPackable>false</IsPackable>
   </PropertyGroup>
@@ -25,12 +25,12 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="nunit" Version="3.12.0" />
+    <PackageReference Include="nunit" Version="3.13.0" />
     <PackageReference Include="NUnit3TestAdapter" Version="3.17.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.7.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.8.3" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Update core package version to fix type conversion for object primitive type when get dictionary from settings file with a key value which was overridden by environment variable

Related to:
https://github.com/aquality-automation/aquality-selenium-core-dotnet/issues/84