### PR TITLE
[Visual Testing] Add ability of visualization checks for the Form +semver: breaking

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,3 +37,4 @@ msbuild.wrn
 .vs/
 
 Log/
+VisualDumps/

--- a/Aquality.Selenium/src/Aquality.Selenium/Aquality.Selenium.csproj
+++ b/Aquality.Selenium/src/Aquality.Selenium/Aquality.Selenium.csproj
@@ -69,7 +69,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Edge.SeleniumTools" Version="3.141.2" />
-    <PackageReference Include="Aquality.Selenium.Core" Version="1.3.1" />
+    <PackageReference Include="Aquality.Selenium.Core" Version="1.6.0" />
     <PackageReference Include="WebDriverManager" Version="2.11.1" />
   </ItemGroup>
 

--- a/Aquality.Selenium/src/Aquality.Selenium/Aquality.Selenium.csproj
+++ b/Aquality.Selenium/src/Aquality.Selenium/Aquality.Selenium.csproj
@@ -69,7 +69,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Edge.SeleniumTools" Version="3.141.2" />
-    <PackageReference Include="Aquality.Selenium.Core" Version="1.6.0" />
+    <PackageReference Include="Aquality.Selenium.Core" Version="1.6.1" />
     <PackageReference Include="WebDriverManager" Version="2.11.1" />
   </ItemGroup>
 

--- a/Aquality.Selenium/src/Aquality.Selenium/Aquality.Selenium.xml
+++ b/Aquality.Selenium/src/Aquality.Selenium/Aquality.Selenium.xml
@@ -1485,6 +1485,21 @@
             Instance of logger <see cref="T:Aquality.Selenium.Core.Logging.Logger"/>
             </summary>
         </member>
+        <member name="P:Aquality.Selenium.Forms.Form.VisualizationConfiguration">
+            <summary>
+            Visualization configuration used by <see cref="P:Aquality.Selenium.Core.Forms.Form`1.Dump"/>.
+            </summary>
+        </member>
+        <member name="P:Aquality.Selenium.Forms.Form.LocalizedLogger">
+            <summary>
+            Localized logger used by <see cref="P:Aquality.Selenium.Core.Forms.Form`1.Dump"/>.
+            </summary>
+        </member>
+        <member name="P:Aquality.Selenium.Forms.Form.ConditionalWait">
+            <summary>
+            Conditional wait <see cref="T:Aquality.Selenium.Core.Waitings.IConditionalWait"/>
+            </summary>
+        </member>
         <member name="P:Aquality.Selenium.Forms.Form.ElementFactory">
             <summary>
             Element factory <see cref="T:Aquality.Selenium.Elements.Interfaces.IElementFactory"/>
@@ -1499,13 +1514,6 @@
             <summary>
             Name of the form.
             </summary>
-        </member>
-        <member name="P:Aquality.Selenium.Forms.Form.IsDisplayed">
-            <summary>
-            Return form state for form locator
-            </summary>
-            <value>True - form is opened,
-            False - form is not opened.</value>
         </member>
         <member name="P:Aquality.Selenium.Forms.Form.State">
             <summary>
@@ -1523,29 +1531,6 @@
             </summary>
             <param name="x">horizontal coordinate</param>
             <param name="y">vertical coordinate</param>
-        </member>
-        <member name="M:Aquality.Selenium.Forms.Form.FindChildElement``1(OpenQA.Selenium.By,System.String,Aquality.Selenium.Core.Elements.ElementSupplier{``0},Aquality.Selenium.Core.Elements.ElementState)">
-            <summary>
-            Finds child element of current form by its locator.
-            </summary>
-            <typeparam name="T">Type of child element that has to implement IElement.</typeparam>
-            <param name="childLocator">Locator of child element relative to form.</param>
-            <param name="name">Child element name.</param>
-            <param name="supplier">Delegate that defines constructor of child element in case of custom element.</param>
-            <param name="state">Child element state.</param>
-            <returns>Instance of child element.</returns>
-        </member>
-        <member name="M:Aquality.Selenium.Forms.Form.FindChildElements``1(OpenQA.Selenium.By,System.String,Aquality.Selenium.Core.Elements.ElementSupplier{``0},Aquality.Selenium.Core.Elements.ElementsCount,Aquality.Selenium.Core.Elements.ElementState)">
-            <summary>
-            Finds child elements of current form by their locator.
-            </summary>
-            <typeparam name="T">Type of child elements that has to implement IElement.</typeparam>
-            <param name="childLocator">Locator of child elements relative to form.</param>
-            <param name="name">Child elements name.</param>
-            <param name="supplier">Delegate that defines constructor of child element in case of custom element type.</param>
-            <param name="expectedCount">Expected number of elements that have to be found (zero, more then zero, any).</param>
-            <param name="state">Child elements state.</param>
-            <returns>List of child elements.</returns>
         </member>
     </members>
 </doc>

--- a/Aquality.Selenium/src/Aquality.Selenium/Browsers/BrowserTabNavigation.cs
+++ b/Aquality.Selenium/src/Aquality.Selenium/Browsers/BrowserTabNavigation.cs
@@ -74,7 +74,7 @@ namespace Aquality.Selenium.Browsers
             var names = TabHandles;
             if (index < 0 || names.Count <= index)
             {
-                throw new IndexOutOfRangeException(
+                throw new ArgumentOutOfRangeException(
                     $"Index of browser tab '{index}' you provided is out of range {0}..{names.Count}");
             }
 

--- a/Aquality.Selenium/src/Aquality.Selenium/Elements/Element.cs
+++ b/Aquality.Selenium/src/Aquality.Selenium/Elements/Element.cs
@@ -1,20 +1,22 @@
-﻿using OpenQA.Selenium;
-using Aquality.Selenium.Browsers;
+﻿using Aquality.Selenium.Browsers;
+using Aquality.Selenium.Configurations;
+using Aquality.Selenium.Core.Applications;
+using Aquality.Selenium.Core.Configurations;
+using Aquality.Selenium.Core.Elements;
+using Aquality.Selenium.Core.Localization;
+using Aquality.Selenium.Core.Logging;
+using Aquality.Selenium.Core.Utilities;
+using Aquality.Selenium.Core.Visualization;
+using Aquality.Selenium.Core.Waitings;
 using Aquality.Selenium.Elements.Actions;
 using Aquality.Selenium.Elements.Interfaces;
-using Aquality.Selenium.Core.Elements;
-using Aquality.Selenium.Configurations;
-using Aquality.Selenium.Core.Utilities;
-using Aquality.Selenium.Core.Applications;
-using Aquality.Selenium.Core.Localization;
-using Aquality.Selenium.Core.Waitings;
+using OpenQA.Selenium;
+using System.Reflection;
+using System.Linq;
 using CoreElement = Aquality.Selenium.Core.Elements.Element;
 using ICoreElementFactory = Aquality.Selenium.Core.Elements.Interfaces.IElementFactory;
 using ICoreElementFinder = Aquality.Selenium.Core.Elements.Interfaces.IElementFinder;
 using ICoreElementStateProvider = Aquality.Selenium.Core.Elements.Interfaces.IElementStateProvider;
-using Aquality.Selenium.Core.Configurations;
-using System.Reflection;
-using System.Linq;
 
 namespace Aquality.Selenium.Elements
 {
@@ -54,6 +56,8 @@ namespace Aquality.Selenium.Elements
         protected override ILocalizationManager LocalizationManager => AqualityServices.Get<ILocalizationManager>();
 
         protected override IConditionalWait ConditionalWait => AqualityServices.ConditionalWait;
+
+        protected override IImageComparator ImageComparator => AqualityServices.Get<IImageComparator>();
 
         public void ClickAndWait()
         {

--- a/Aquality.Selenium/src/Aquality.Selenium/Elements/ElementStateProvider.cs
+++ b/Aquality.Selenium/src/Aquality.Selenium/Elements/ElementStateProvider.cs
@@ -1,5 +1,5 @@
-﻿using Aquality.Selenium.Core.Elements;
-using Aquality.Selenium.Core.Elements.Interfaces;
+﻿using Aquality.Selenium.Core.Elements.Interfaces;
+using Aquality.Selenium.Core.Logging;
 using Aquality.Selenium.Core.Waitings;
 using OpenQA.Selenium;
 using CoreElementStateProvider = Aquality.Selenium.Core.Elements.ElementStateProvider;

--- a/Aquality.Selenium/src/Aquality.Selenium/Forms/Form.cs
+++ b/Aquality.Selenium/src/Aquality.Selenium/Forms/Form.cs
@@ -1,19 +1,20 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Drawing;
-using OpenQA.Selenium;
-using Aquality.Selenium.Core.Elements;
-using Aquality.Selenium.Core.Logging;
+﻿using System.Drawing;
 using Aquality.Selenium.Browsers;
+using Aquality.Selenium.Core.Logging;
+using Aquality.Selenium.Core.Forms;
 using Aquality.Selenium.Elements.Interfaces;
+using OpenQA.Selenium;
 using IElementStateProvider = Aquality.Selenium.Core.Elements.Interfaces.IElementStateProvider;
+using Aquality.Selenium.Core.Configurations;
+using Aquality.Selenium.Core.Localization;
+using Aquality.Selenium.Core.Waitings;
 
 namespace Aquality.Selenium.Forms
 {
     /// <summary>
     /// Defines base class for any UI form.
     /// </summary>
-    public abstract class Form
+    public abstract class Form : Form<IElement>
     {
         private readonly ILabel formLabel;
         /// <summary>
@@ -40,6 +41,21 @@ namespace Aquality.Selenium.Forms
         protected static Logger Logger => AqualityServices.Logger;
 
         /// <summary>
+        /// Visualization configuration used by <see cref="Form{T}.Dump"/>.
+        /// </summary>
+        protected override IVisualizationConfiguration VisualizationConfiguration => AqualityServices.Get<IVisualizationConfiguration>();
+
+        /// <summary>
+        /// Localized logger used by <see cref="Form{T}.Dump"/>.
+        /// </summary>
+        protected override ILocalizedLogger LocalizedLogger => AqualityServices.LocalizedLogger;
+
+        /// <summary>
+        /// Conditional wait <see cref="IConditionalWait"/>
+        /// </summary>
+        protected static IConditionalWait ConditionalWait => AqualityServices.ConditionalWait;
+
+        /// <summary>
         /// Element factory <see cref="IElementFactory"/>
         /// </summary>
         protected static IElementFactory ElementFactory => AqualityServices.Get<IElementFactory>();
@@ -52,15 +68,7 @@ namespace Aquality.Selenium.Forms
         /// <summary>
         /// Name of the form.
         /// </summary>
-        public string Name { get; }
-
-        /// <summary>
-        /// Return form state for form locator
-        /// </summary>
-        /// <value>True - form is opened,
-        /// False - form is not opened.</value>
-        [Obsolete("This property will be removed in the future release. Use State.WaitForDisplayed() if needed")] 
-        public bool IsDisplayed => FormElement.State.WaitForDisplayed();
+        public override string Name { get; }
 
         /// <summary>
         /// Provides ability to get form's state (whether it is displayed, exists or not) and respective waiting functions.
@@ -70,7 +78,7 @@ namespace Aquality.Selenium.Forms
         /// <summary>
         /// Gets size of form element defined by its locator.
         /// </summary>
-        public Size Size => FormElement.GetElement().Size;
+        public Size Size => FormElement.Visual.Size;
 
         /// <summary>
         /// Scroll form without scrolling entire page
@@ -80,39 +88,6 @@ namespace Aquality.Selenium.Forms
         public void ScrollBy(int x, int y)
         {
             FormElement.JsActions.ScrollBy(x, y);
-        }
-
-        /// <summary>
-        /// Finds child element of current form by its locator.
-        /// </summary>
-        /// <typeparam name="T">Type of child element that has to implement IElement.</typeparam>
-        /// <param name="childLocator">Locator of child element relative to form.</param>
-        /// <param name="name">Child element name.</param>
-        /// <param name="supplier">Delegate that defines constructor of child element in case of custom element.</param>
-        /// <param name="state">Child element state.</param>
-        /// <returns>Instance of child element.</returns>
-        [Obsolete("This method will be removed in the future release. Use FormElement property methods to find child element")]
-        protected T FindChildElement<T>(By childLocator, string name = null, ElementSupplier<T> supplier = null, ElementState state = ElementState.Displayed) 
-            where T : IElement
-        {
-            return FormElement.FindChildElement(childLocator, name, supplier, state);
-        }
-
-        /// <summary>
-        /// Finds child elements of current form by their locator.
-        /// </summary>
-        /// <typeparam name="T">Type of child elements that has to implement IElement.</typeparam>
-        /// <param name="childLocator">Locator of child elements relative to form.</param>
-        /// <param name="name">Child elements name.</param>
-        /// <param name="supplier">Delegate that defines constructor of child element in case of custom element type.</param>
-        /// <param name="expectedCount">Expected number of elements that have to be found (zero, more then zero, any).</param>
-        /// <param name="state">Child elements state.</param>
-        /// <returns>List of child elements.</returns>
-        [Obsolete("This method will be removed in the future release. Use FormElement property methods to find child elements")]
-        protected IList<T> FindChildElements<T>(By childLocator, string name = null, ElementSupplier<T> supplier = null, ElementsCount expectedCount = ElementsCount.Any, ElementState state = ElementState.Displayed) 
-            where T : IElement
-        {
-            return FormElement.FindChildElements(childLocator, name, supplier, expectedCount, state);
         }
     }
 }

--- a/Aquality.Selenium/src/Aquality.Selenium/Resources/settings.json
+++ b/Aquality.Selenium/src/Aquality.Selenium/Resources/settings.json
@@ -110,5 +110,11 @@
   },
   "elementCache": {
     "isEnabled": false
+  },
+  "visualization": {
+    "defaultThreshold": 0.012,
+    "comparisonWidth": 16,
+    "comparisonHeight": 16,
+    "pathToDumps": "../../../Resources/VisualDumps/"
   }
 }

--- a/Aquality.Selenium/tests/Aquality.Selenium.Tests/Aquality.Selenium.Tests.csproj
+++ b/Aquality.Selenium/tests/Aquality.Selenium.Tests/Aquality.Selenium.Tests.csproj
@@ -25,12 +25,12 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="nunit" Version="3.13.0" />
+    <PackageReference Include="nunit" Version="3.13.2" />
     <PackageReference Include="NUnit3TestAdapter" Version="3.17.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.8.3" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.10.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Aquality.Selenium/tests/Aquality.Selenium.Tests/Integration/Actions/JsActionsTests.cs
+++ b/Aquality.Selenium/tests/Aquality.Selenium.Tests/Integration/Actions/JsActionsTests.cs
@@ -5,7 +5,6 @@ using System.Linq;
 using Aquality.Selenium.Browsers;
 using Aquality.Selenium.Core.Elements;
 using Aquality.Selenium.Elements;
-using Aquality.Selenium.Tests.Integration.TestApp;
 using Aquality.Selenium.Tests.Integration.TestApp.AutomationPractice.Forms;
 using Aquality.Selenium.Tests.Integration.TestApp.TheInternet.Forms;
 using NUnit.Framework;

--- a/Aquality.Selenium/tests/Aquality.Selenium.Tests/Integration/Actions/JsActionsTests.cs
+++ b/Aquality.Selenium/tests/Aquality.Selenium.Tests/Integration/Actions/JsActionsTests.cs
@@ -47,7 +47,7 @@ namespace Aquality.Selenium.Tests.Integration.Actions
         [Test]
         public void Should_BePossibleTo_HoverMouse()
         {
-            AqualityServices.Browser.GoTo(Constants.UrlAutomationPractice);
+            OpenAutomationPracticeSite();
             var productList = new ProductListForm();
             productList.NavigateToLastProduct();
 
@@ -60,7 +60,7 @@ namespace Aquality.Selenium.Tests.Integration.Actions
         [Test]
         public void Should_BePossibleTo_SetFocus()
         {
-            AqualityServices.Browser.GoTo(Constants.UrlAutomationPractice);
+            OpenAutomationPracticeSite();
             var productList = new ProductListForm();
             productList.NavigateToLastProduct();
 

--- a/Aquality.Selenium/tests/Aquality.Selenium.Tests/Integration/Actions/MouseActionsTests.cs
+++ b/Aquality.Selenium/tests/Aquality.Selenium.Tests/Integration/Actions/MouseActionsTests.cs
@@ -39,7 +39,7 @@ namespace Aquality.Selenium.Tests.Integration.Actions
         [Test]
         public void Should_BePossibleTo_MoveToElement()
         {
-            AqualityServices.Browser.GoTo(Constants.UrlAutomationPractice);
+            OpenAutomationPracticeSite();
             var productList = new ProductListForm();
             productList.NavigateToLastProduct();
 

--- a/Aquality.Selenium/tests/Aquality.Selenium.Tests/Integration/Actions/MouseActionsTests.cs
+++ b/Aquality.Selenium/tests/Aquality.Selenium.Tests/Integration/Actions/MouseActionsTests.cs
@@ -1,5 +1,4 @@
 using Aquality.Selenium.Browsers;
-using Aquality.Selenium.Tests.Integration.TestApp;
 using Aquality.Selenium.Tests.Integration.TestApp.AutomationPractice.Forms;
 using Aquality.Selenium.Tests.Integration.TestApp.TheInternet.Forms;
 using NUnit.Framework;

--- a/Aquality.Selenium/tests/Aquality.Selenium.Tests/Integration/BrowserTabsTests.cs
+++ b/Aquality.Selenium/tests/Aquality.Selenium.Tests/Integration/BrowserTabsTests.cs
@@ -135,7 +135,7 @@ namespace Aquality.Selenium.Tests.Integration
         [Test]
         public void Should_BeThrow_IfSwitchToNewTab_ByIncorrectIndex()
         {
-            Assert.Throws(typeof(IndexOutOfRangeException), () => { AqualityServices.Browser.Tabs().SwitchToTab(10, true); });
+            Assert.Throws<ArgumentOutOfRangeException>(() => { AqualityServices.Browser.Tabs().SwitchToTab(10, true); });
         }
 
         private void CheckSwitchingBy(int expectedTabCount, Action switchMethod)

--- a/Aquality.Selenium/tests/Aquality.Selenium.Tests/Integration/BrowserTests.cs
+++ b/Aquality.Selenium/tests/Aquality.Selenium.Tests/Integration/BrowserTests.cs
@@ -1,5 +1,4 @@
 ﻿using Aquality.Selenium.Browsers;
-using Aquality.Selenium.Tests.Integration.TestApp;
 using Aquality.Selenium.Tests.Integration.TestApp.AutomationPractice.Forms;
 using Aquality.Selenium.Tests.Integration.TestApp.TheInternet.Forms;
 using TheInternetAuthenticationForm = Aquality.Selenium.Tests.Integration.TestApp.TheInternet.Forms.AuthenticationForm;

--- a/Aquality.Selenium/tests/Aquality.Selenium.Tests/Integration/BrowserTests.cs
+++ b/Aquality.Selenium/tests/Aquality.Selenium.Tests/Integration/BrowserTests.cs
@@ -189,12 +189,11 @@ namespace Aquality.Selenium.Tests.Integration
         [Test]
         public void Should_BePossibleTo_ScrollWindowBy()
         {
-            var browser = AqualityServices.Browser;
-            browser.GoTo(Constants.UrlAutomationPractice);
+            OpenAutomationPracticeSite();
             var sliderForm = new SliderForm();
             var initialY = sliderForm.FormPointInViewPort.Y;
             var formHeight = sliderForm.Size.Height;
-            browser.ScrollWindowBy(0, formHeight);
+            AqualityServices.Browser.ScrollWindowBy(0, formHeight);
             Assert.LessOrEqual(Math.Abs(formHeight - (initialY - sliderForm.FormPointInViewPort.Y)), 1, "Window should be scrolled.");
         }
 

--- a/Aquality.Selenium/tests/Aquality.Selenium.Tests/Integration/HiddenElementsTests.cs
+++ b/Aquality.Selenium/tests/Aquality.Selenium.Tests/Integration/HiddenElementsTests.cs
@@ -1,7 +1,5 @@
-﻿using Aquality.Selenium.Browsers;
-using Aquality.Selenium.Core.Elements;
+﻿using Aquality.Selenium.Core.Elements;
 using Aquality.Selenium.Elements;
-using Aquality.Selenium.Tests.Integration.TestApp;
 using Aquality.Selenium.Tests.Integration.TestApp.AutomationPractice.Forms;
 using NUnit.Framework;
 using System;

--- a/Aquality.Selenium/tests/Aquality.Selenium.Tests/Integration/HiddenElementsTests.cs
+++ b/Aquality.Selenium/tests/Aquality.Selenium.Tests/Integration/HiddenElementsTests.cs
@@ -30,7 +30,7 @@ namespace Aquality.Selenium.Tests.Integration
         [SetUp]
         public void BeforeTest()
         {
-            AqualityServices.Browser.GoTo(Constants.UrlAutomationPractice);
+            OpenAutomationPracticeSite();
         }
 
         [Test]

--- a/Aquality.Selenium/tests/Aquality.Selenium.Tests/Integration/TestApp/AutomationPractice/Forms/ProductListForm.cs
+++ b/Aquality.Selenium/tests/Aquality.Selenium.Tests/Integration/TestApp/AutomationPractice/Forms/ProductListForm.cs
@@ -5,6 +5,7 @@ using Aquality.Selenium.Browsers;
 using Aquality.Selenium.Core.Elements;
 using Aquality.Selenium.Elements.Interfaces;
 using Aquality.Selenium.Forms;
+using Aquality.Selenium.Tests.Integration.TestApp.AutomationPractice.Helpers;
 using OpenQA.Selenium;
 
 namespace Aquality.Selenium.Tests.Integration.TestApp.AutomationPractice.Forms
@@ -26,8 +27,7 @@ namespace Aquality.Selenium.Tests.Integration.TestApp.AutomationPractice.Forms
 
         public void NavigateToLastProduct()
         {
-            AqualityServices.Browser.GoTo(GetLastProduct().Href);
-            AqualityServices.Browser.WaitForPageToLoad();
+            SiteLoader.OpenAutomationPracticeSite(GetLastProduct().Href);
         }
 
         public ILink GetLastProduct()

--- a/Aquality.Selenium/tests/Aquality.Selenium.Tests/Integration/TestApp/AutomationPractice/Forms/SliderForm.cs
+++ b/Aquality.Selenium/tests/Aquality.Selenium.Tests/Integration/TestApp/AutomationPractice/Forms/SliderForm.cs
@@ -2,19 +2,40 @@
 using Aquality.Selenium.Elements.Interfaces;
 using Aquality.Selenium.Forms;
 using OpenQA.Selenium;
+using System.Collections.Generic;
 using System.Drawing;
 
 namespace Aquality.Selenium.Tests.Integration.TestApp.AutomationPractice.Forms
 {
     internal class SliderForm : Form
     {
+        private readonly ILabel styleContainer = ElementFactory.GetLabel(By.Id("homeslider"), "Slider style container", ElementState.ExistsInAnyState);
+
         public SliderForm() : base(By.Id("slider_row"), "Slider")
         {
         }
 
+        protected override IDictionary<string, IElement> ElementsForVisualization => ElementsInitializedAsDisplayed;
+
         public IButton NextButton => ElementFactory.GetButton(By.XPath("//a[contains(.,'Next')]"), "Next");
 
         public Point FormPointInViewPort => ElementFactory.GetLabel(Locator, Name).JsActions.GetViewPortCoordinates();
+
+        public string Style => styleContainer.GetAttribute("style");
+
+        public void WaitForSliding()
+        {
+            var style = string.Empty;
+            ConditionalWait.WaitForTrue(() =>
+            {
+                if (style == Style)
+                {
+                    return true;
+                }
+                style = Style;
+                return false;
+            }, message: "Sliding should stop after a while");
+        }
 
         public IButton GetAddToCartBtn(ElementState elementState)
         {

--- a/Aquality.Selenium/tests/Aquality.Selenium.Tests/Integration/TestApp/AutomationPractice/Helpers/SiteLoader.cs
+++ b/Aquality.Selenium/tests/Aquality.Selenium.Tests/Integration/TestApp/AutomationPractice/Helpers/SiteLoader.cs
@@ -1,0 +1,29 @@
+﻿using Aquality.Selenium.Elements.Interfaces;
+using OpenQA.Selenium;
+using System;
+using static Aquality.Selenium.Browsers.AqualityServices;
+
+namespace Aquality.Selenium.Tests.Integration.TestApp.AutomationPractice.Helpers
+{
+    internal static class SiteLoader
+    {
+        public static void OpenAutomationPracticeSite(string customUrl = null)
+        {
+            var resourceLimitLabel = Get<IElementFactory>()
+                .GetLabel(By.XPath("//h1[.='Resource Limit Is Reached']"), "Resource Limit Is Reached");
+            Browser.GoTo(customUrl ?? Constants.UrlAutomationPractice);
+            Browser.WaitForPageToLoad();
+            ConditionalWait.WaitForTrue(() =>
+            {
+                if (resourceLimitLabel.State.IsDisplayed)
+                {
+                    Browser.Refresh();
+                    Browser.WaitForPageToLoad();
+                    return false;
+                }
+                return true;
+            }, timeout: TimeSpan.FromMinutes(3), pollingInterval: TimeSpan.FromSeconds(15),
+            message: $"Failed to load [{customUrl ?? Constants.UrlAutomationPractice}] website. {resourceLimitLabel.Name} message is displayed.");
+        }
+    }
+}

--- a/Aquality.Selenium/tests/Aquality.Selenium.Tests/Integration/UITest.cs
+++ b/Aquality.Selenium/tests/Aquality.Selenium.Tests/Integration/UITest.cs
@@ -1,6 +1,7 @@
-﻿using static Aquality.Selenium.Browsers.AqualityServices;
+﻿using Aquality.Selenium.Browsers;
 using Aquality.Selenium.Elements.Interfaces;
 using Aquality.Selenium.Tests.Integration.TestApp;
+using Aquality.Selenium.Tests.Integration.TestApp.AutomationPractice.Helpers;
 using NUnit.Framework;
 using OpenQA.Selenium;
 using System;
@@ -15,29 +16,15 @@ namespace Aquality.Selenium.Tests.Integration
         [TearDown]
         public void CleanUp()
         {
-            if (IsBrowserStarted)
+            if (AqualityServices.IsBrowserStarted)
             {
-                Browser.Quit();
+                AqualityServices.Browser.Quit();
             }
         }
 
         protected void OpenAutomationPracticeSite()
         {
-            var resourceLimitLabel = Get<IElementFactory>()
-                .GetLabel(By.XPath("//h1[.='Resource Limit Is Reached']"), "Resource Limit Is Reached");
-            Browser.GoTo(Constants.UrlAutomationPractice);
-            Browser.WaitForPageToLoad();
-            ConditionalWait.WaitForTrue(() =>
-            {
-                if (resourceLimitLabel.State.IsDisplayed)
-                {
-                    Browser.Refresh();
-                    Browser.WaitForPageToLoad();
-                    return false;
-                }
-                return true;
-            }, timeout: TimeSpan.FromMinutes(3), pollingInterval: TimeSpan.FromSeconds(15), 
-            message: $"Failed to load [{Constants.UrlAutomationPractice}] website. {resourceLimitLabel.Name} message is displayed.");
+            SiteLoader.OpenAutomationPracticeSite();
         }
     }
 }

--- a/Aquality.Selenium/tests/Aquality.Selenium.Tests/Integration/UITest.cs
+++ b/Aquality.Selenium/tests/Aquality.Selenium.Tests/Integration/UITest.cs
@@ -1,10 +1,6 @@
 ﻿using Aquality.Selenium.Browsers;
-using Aquality.Selenium.Elements.Interfaces;
-using Aquality.Selenium.Tests.Integration.TestApp;
 using Aquality.Selenium.Tests.Integration.TestApp.AutomationPractice.Helpers;
 using NUnit.Framework;
-using OpenQA.Selenium;
-using System;
 
 [assembly: LevelOfParallelism(10)]
 namespace Aquality.Selenium.Tests.Integration
@@ -22,7 +18,7 @@ namespace Aquality.Selenium.Tests.Integration
             }
         }
 
-        protected void OpenAutomationPracticeSite()
+        protected static void OpenAutomationPracticeSite()
         {
             SiteLoader.OpenAutomationPracticeSite();
         }

--- a/Aquality.Selenium/tests/Aquality.Selenium.Tests/Integration/UITest.cs
+++ b/Aquality.Selenium/tests/Aquality.Selenium.Tests/Integration/UITest.cs
@@ -1,5 +1,9 @@
-﻿using Aquality.Selenium.Browsers;
+﻿using static Aquality.Selenium.Browsers.AqualityServices;
+using Aquality.Selenium.Elements.Interfaces;
+using Aquality.Selenium.Tests.Integration.TestApp;
 using NUnit.Framework;
+using OpenQA.Selenium;
+using System;
 
 [assembly: LevelOfParallelism(10)]
 namespace Aquality.Selenium.Tests.Integration
@@ -11,10 +15,29 @@ namespace Aquality.Selenium.Tests.Integration
         [TearDown]
         public void CleanUp()
         {
-            if (AqualityServices.IsBrowserStarted)
+            if (IsBrowserStarted)
             {
-                AqualityServices.Browser.Quit();
+                Browser.Quit();
             }
+        }
+
+        protected void OpenAutomationPracticeSite()
+        {
+            var resourceLimitLabel = Get<IElementFactory>()
+                .GetLabel(By.XPath("//h1[.='Resource Limit Is Reached']"), "Resource Limit Is Reached");
+            Browser.GoTo(Constants.UrlAutomationPractice);
+            Browser.WaitForPageToLoad();
+            ConditionalWait.WaitForTrue(() =>
+            {
+                if (resourceLimitLabel.State.IsDisplayed)
+                {
+                    Browser.Refresh();
+                    Browser.WaitForPageToLoad();
+                    return false;
+                }
+                return true;
+            }, timeout: TimeSpan.FromMinutes(3), pollingInterval: TimeSpan.FromSeconds(15), 
+            message: $"Failed to load [{Constants.UrlAutomationPractice}] website. {resourceLimitLabel.Name} message is displayed.");
         }
     }
 }

--- a/Aquality.Selenium/tests/Aquality.Selenium.Tests/Integration/Usecases/ElementExistsButNotDisplayedTests.cs
+++ b/Aquality.Selenium/tests/Aquality.Selenium.Tests/Integration/Usecases/ElementExistsButNotDisplayedTests.cs
@@ -1,7 +1,6 @@
 ﻿using Aquality.Selenium.Browsers;
 using Aquality.Selenium.Core.Elements;
 using Aquality.Selenium.Elements.Interfaces;
-using Aquality.Selenium.Tests.Integration.TestApp;
 using Aquality.Selenium.Tests.Integration.TestApp.AutomationPractice.Forms;
 using NUnit.Framework;
 using OpenQA.Selenium;

--- a/Aquality.Selenium/tests/Aquality.Selenium.Tests/Integration/Usecases/ElementExistsButNotDisplayedTests.cs
+++ b/Aquality.Selenium/tests/Aquality.Selenium.Tests/Integration/Usecases/ElementExistsButNotDisplayedTests.cs
@@ -18,7 +18,7 @@ namespace Aquality.Selenium.Tests.Integration.Usecases
         [SetUp]
         public void BeforeTest()
         {
-            AqualityServices.Browser.GoTo(Constants.UrlAutomationPractice);
+            OpenAutomationPracticeSite();
         }
 
         [Test]

--- a/Aquality.Selenium/tests/Aquality.Selenium.Tests/Integration/Usecases/ShoppingCartTests.cs
+++ b/Aquality.Selenium/tests/Aquality.Selenium.Tests/Integration/Usecases/ShoppingCartTests.cs
@@ -24,8 +24,12 @@ namespace Aquality.Selenium.Tests.Integration.Usecases
         public void Should_BePossibleTo_PerformActions()
         {
             // website automationpractice.com is out of resources and unable to proceed operations sometimes
-            AqualityServices.Get<IActionRetrier>().DoWithRetry(ActionsOnAutomationPractice, 
-                new[] { typeof(NoSuchElementException), typeof(WebDriverTimeoutException) });
+            Assert.DoesNotThrow(() =>
+            {
+                AqualityServices.Get<IActionRetrier>().DoWithRetry(ActionsOnAutomationPractice,
+                   new[] { typeof(NoSuchElementException), typeof(WebDriverTimeoutException) });
+            }, "Shopping cart actions should actually work");
+            
         }
 
         private void ActionsOnAutomationPractice()

--- a/Aquality.Selenium/tests/Aquality.Selenium.Tests/Integration/Usecases/ShoppingCartTests.cs
+++ b/Aquality.Selenium/tests/Aquality.Selenium.Tests/Integration/Usecases/ShoppingCartTests.cs
@@ -1,8 +1,10 @@
 ﻿using Aquality.Selenium.Browsers;
+using Aquality.Selenium.Core.Utilities;
 using Aquality.Selenium.Tests.Integration.TestApp;
 using Aquality.Selenium.Tests.Integration.TestApp.AutomationPractice.Forms;
 using Aquality.Selenium.Tests.Integration.TestApp.AutomationPractice.Modals;
 using NUnit.Framework;
+using OpenQA.Selenium;
 using System;
 
 namespace Aquality.Selenium.Tests.Integration.Usecases
@@ -17,18 +19,20 @@ namespace Aquality.Selenium.Tests.Integration.Usecases
         private static readonly int DayToSelect = 29;
         private static readonly string State = "California";
 
-        private string Email => $"john+{DateTime.Now.Millisecond}@doe.com";
-
-        [SetUp]
-        public void BeforeTest()
-        {
-            AqualityServices.Browser.GoTo(Constants.UrlAutomationPractice);
-            AqualityServices.Browser.Maximize();
-        }
+        private static string Email => $"john+{DateTime.Now.Millisecond}@doe.com";
 
         [Test]
         public void Should_BePossibleTo_PerformActions()
         {
+            // website automationpractice.com is out of resources and unable to proceed operations sometimes
+            AqualityServices.Get<IActionRetrier>().DoWithRetry(ActionsOnAutomationPractice, new[] { typeof(NoSuchElementException) });
+        }
+
+        private void ActionsOnAutomationPractice()
+        {
+            AqualityServices.Browser.Quit();
+            OpenAutomationPracticeSite();
+            AqualityServices.Browser.Maximize();
             var sliderForm = new SliderForm();
             Assert.IsTrue(sliderForm.State.WaitForDisplayed(), "Slider Form is not opened");
 

--- a/Aquality.Selenium/tests/Aquality.Selenium.Tests/Integration/Usecases/ShoppingCartTests.cs
+++ b/Aquality.Selenium/tests/Aquality.Selenium.Tests/Integration/Usecases/ShoppingCartTests.cs
@@ -27,6 +27,23 @@ namespace Aquality.Selenium.Tests.Integration.Usecases
         }
 
         [Test]
+        public void Should_BePossibleTo_CheckVisualState()
+        {
+            var sliderForm = new SliderForm();
+            Assume.That(sliderForm.State.WaitForDisplayed(), "Slider Form is not opened");
+            var style = sliderForm.Style;
+            Assert.DoesNotThrow(() => sliderForm.Dump.Save(), "Should be possible to save dump");
+            Assert.That(sliderForm.Dump.Compare() == 0L || sliderForm.Style != style, "Form dump should remain the same, unless the slider has already scrolled");
+            sliderForm.ClickNextButton();
+            Assert.That(sliderForm.Dump.Compare(), Is.GreaterThan(0), "After clicking on slider next button, the form dump should differ");
+            Assert.That(AqualityServices.ConditionalWait.WaitFor(() =>
+            {
+                sliderForm.ClickNextButton();
+                return sliderForm.Dump.Compare() == 0L;
+            }), "After some clicking on slider the form dump should be the same as initial");
+        }
+
+        [Test]
         public void Should_BePossibleTo_PerformActions()
         {
             var sliderForm = new SliderForm();

--- a/Aquality.Selenium/tests/Aquality.Selenium.Tests/Integration/Usecases/ShoppingCartTests.cs
+++ b/Aquality.Selenium/tests/Aquality.Selenium.Tests/Integration/Usecases/ShoppingCartTests.cs
@@ -1,6 +1,5 @@
 ﻿using Aquality.Selenium.Browsers;
 using Aquality.Selenium.Core.Utilities;
-using Aquality.Selenium.Tests.Integration.TestApp;
 using Aquality.Selenium.Tests.Integration.TestApp.AutomationPractice.Forms;
 using Aquality.Selenium.Tests.Integration.TestApp.AutomationPractice.Modals;
 using NUnit.Framework;
@@ -25,7 +24,8 @@ namespace Aquality.Selenium.Tests.Integration.Usecases
         public void Should_BePossibleTo_PerformActions()
         {
             // website automationpractice.com is out of resources and unable to proceed operations sometimes
-            AqualityServices.Get<IActionRetrier>().DoWithRetry(ActionsOnAutomationPractice, new[] { typeof(NoSuchElementException) });
+            AqualityServices.Get<IActionRetrier>().DoWithRetry(ActionsOnAutomationPractice, 
+                new[] { typeof(NoSuchElementException), typeof(WebDriverTimeoutException) });
         }
 
         private void ActionsOnAutomationPractice()

--- a/Aquality.Selenium/tests/Aquality.Selenium.Tests/Integration/Usecases/ShoppingCartTests.cs
+++ b/Aquality.Selenium/tests/Aquality.Selenium.Tests/Integration/Usecases/ShoppingCartTests.cs
@@ -27,7 +27,7 @@ namespace Aquality.Selenium.Tests.Integration.Usecases
             Assert.DoesNotThrow(() =>
             {
                 AqualityServices.Get<IActionRetrier>().DoWithRetry(ActionsOnAutomationPractice,
-                   new[] { typeof(NoSuchElementException), typeof(WebDriverTimeoutException) });
+                   new[] { typeof(NoSuchElementException), typeof(WebDriverTimeoutException), typeof(AssertionException) });
             }, "Shopping cart actions should actually work");
             
         }

--- a/Aquality.Selenium/tests/Aquality.Selenium.Tests/Integration/Usecases/ShoppingCartTests.cs
+++ b/Aquality.Selenium/tests/Aquality.Selenium.Tests/Integration/Usecases/ShoppingCartTests.cs
@@ -27,23 +27,6 @@ namespace Aquality.Selenium.Tests.Integration.Usecases
         }
 
         [Test]
-        public void Should_BePossibleTo_CheckVisualState()
-        {
-            var sliderForm = new SliderForm();
-            Assume.That(sliderForm.State.WaitForDisplayed(), "Slider Form is not opened");
-            var style = sliderForm.Style;
-            Assert.DoesNotThrow(() => sliderForm.Dump.Save(), "Should be possible to save dump");
-            Assert.That(sliderForm.Dump.Compare() == 0L || sliderForm.Style != style, "Form dump should remain the same, unless the slider has already scrolled");
-            sliderForm.ClickNextButton();
-            Assert.That(sliderForm.Dump.Compare(), Is.GreaterThan(0), "After clicking on slider next button, the form dump should differ");
-            Assert.That(AqualityServices.ConditionalWait.WaitFor(() =>
-            {
-                sliderForm.ClickNextButton();
-                return sliderForm.Dump.Compare() == 0L;
-            }), "After some clicking on slider the form dump should be the same as initial");
-        }
-
-        [Test]
         public void Should_BePossibleTo_PerformActions()
         {
             var sliderForm = new SliderForm();

--- a/Aquality.Selenium/tests/Aquality.Selenium.Tests/Integration/Usecases/VisualTests.cs
+++ b/Aquality.Selenium/tests/Aquality.Selenium.Tests/Integration/Usecases/VisualTests.cs
@@ -1,0 +1,62 @@
+﻿using Aquality.Selenium.Browsers;
+using Aquality.Selenium.Tests.Integration.TestApp;
+using Aquality.Selenium.Tests.Integration.TestApp.AutomationPractice.Forms;
+using NUnit.Framework;
+
+namespace Aquality.Selenium.Tests.Integration.Usecases
+{
+    internal class VisualTests : UITest
+    {
+        [SetUp]
+        public void BeforeTest()
+        {
+            AqualityServices.Browser.GoTo(Constants.UrlAutomationPractice);
+            AqualityServices.Browser.Maximize();
+        }
+
+        [Test]
+        public void Should_BePossibleTo_CheckVisualState_WhenItHasNotChanged()
+        {
+            var sliderForm = new SliderForm();
+            Assume.That(sliderForm.State.WaitForDisplayed(), "Slider Form is not opened");
+            var style = sliderForm.Style;
+            Assert.DoesNotThrow(() => sliderForm.Dump.Save(), "Should be possible to save dump");
+            Assert.That(sliderForm.Dump.Compare() == 0L || sliderForm.Style != style, "Form dump should remain the same, unless the slider has already scrolled");
+        }
+
+        [Test]
+        public void Should_BePossibleTo_CheckVisualState_WhenItDifferes()
+        {
+            const string dumpName = "the differed slider";
+            var sliderForm = new SliderForm();
+            Assume.That(sliderForm.State.WaitForDisplayed(), "Slider Form is not opened");
+            var style = sliderForm.Style;
+            Assert.DoesNotThrow(() => sliderForm.Dump.Save(dumpName), "Should be possible to save dump");
+            sliderForm.ClickNextButton();
+            sliderForm.WaitForSliding();
+            Assert.That(sliderForm.Dump.Compare(dumpName), Is.GreaterThan(0), "After clicking on slider next button, the form dump should differ");
+        }
+
+        [Test]
+        public void Should_BePossibleTo_CheckVisualState_WhenItIsTheSame()
+        {
+            const string dumpName = "the same slider";
+            var sliderForm = new SliderForm();
+            Assume.That(sliderForm.State.WaitForDisplayed(), "Slider Form is not opened");
+            sliderForm.ClickNextButton();
+            sliderForm.WaitForSliding();
+            var style = sliderForm.Style;
+            Assert.DoesNotThrow(() => sliderForm.Dump.Save(dumpName), "Should be possible to save dump"); 
+            sliderForm.ClickNextButton();
+            sliderForm.WaitForSliding();
+            Assert.That(sliderForm.Dump.Compare(dumpName), Is.GreaterThan(0), "After clicking on slider next button, the form dump should differ");
+            AqualityServices.ConditionalWait.WaitForTrue(() =>
+            {
+                sliderForm.ClickNextButton();
+                sliderForm.WaitForSliding();
+                return style == sliderForm.Style;
+            }, message: "After some sliding, slider should get back to first slide");
+            Assert.That(sliderForm.Dump.Compare(dumpName), Is.AtMost(0.02), "After slider returned to initial state, the form dump should be almost the same");
+        }
+    }
+}

--- a/Aquality.Selenium/tests/Aquality.Selenium.Tests/Integration/Usecases/VisualTests.cs
+++ b/Aquality.Selenium/tests/Aquality.Selenium.Tests/Integration/Usecases/VisualTests.cs
@@ -44,6 +44,7 @@ namespace Aquality.Selenium.Tests.Integration.Usecases
             var sliderForm = new SliderForm();
             Assume.That(sliderForm.State.WaitForDisplayed(), "Slider Form is not opened");
             sliderForm.ClickNextButton();
+            sliderForm.ClickNextButton();
             sliderForm.WaitForSliding();
             var style = sliderForm.Style;
             Assert.DoesNotThrow(() => sliderForm.Dump.Save(dumpName), "Should be possible to save dump"); 

--- a/Aquality.Selenium/tests/Aquality.Selenium.Tests/Integration/Usecases/VisualTests.cs
+++ b/Aquality.Selenium/tests/Aquality.Selenium.Tests/Integration/Usecases/VisualTests.cs
@@ -10,7 +10,7 @@ namespace Aquality.Selenium.Tests.Integration.Usecases
         [SetUp]
         public void BeforeTest()
         {
-            AqualityServices.Browser.GoTo(Constants.UrlAutomationPractice);
+            OpenAutomationPracticeSite();
             AqualityServices.Browser.Maximize();
         }
 

--- a/Aquality.Selenium/tests/Aquality.Selenium.Tests/Integration/Usecases/VisualTests.cs
+++ b/Aquality.Selenium/tests/Aquality.Selenium.Tests/Integration/Usecases/VisualTests.cs
@@ -1,5 +1,4 @@
 ﻿using Aquality.Selenium.Browsers;
-using Aquality.Selenium.Tests.Integration.TestApp;
 using Aquality.Selenium.Tests.Integration.TestApp.AutomationPractice.Forms;
 using NUnit.Framework;
 

--- a/Aquality.Selenium/tests/Aquality.Selenium.Tests/Resources/settings.azure.json
+++ b/Aquality.Selenium/tests/Aquality.Selenium.Tests/Resources/settings.azure.json
@@ -101,5 +101,11 @@
   },
   "elementCache": {
     "isEnabled": false
+  },
+  "visualization": {
+    "defaultThreshold": 0.012,
+    "comparisonWidth": 16,
+    "comparisonHeight": 16,
+    "pathToDumps": "../../../Resources/VisualDumps/"
   }
 }

--- a/Aquality.Selenium/tests/Aquality.Selenium.Tests/Resources/settings.azure.json
+++ b/Aquality.Selenium/tests/Aquality.Selenium.Tests/Resources/settings.azure.json
@@ -85,7 +85,7 @@
   },
   "timeouts": {
     "timeoutImplicit": 0,
-    "timeoutCondition": 30,
+    "timeoutCondition": 45,
     "timeoutScript": 10,
     "timeoutPageLoad": 60,
     "timeoutPollingInterval": 300,

--- a/Aquality.Selenium/tests/Aquality.Selenium.Tests/Resources/settings.json
+++ b/Aquality.Selenium/tests/Aquality.Selenium.Tests/Resources/settings.json
@@ -104,5 +104,11 @@
   },
   "elementCache": {
     "isEnabled": false
+  },
+  "visualization": {
+    "defaultThreshold": 0.012,
+    "comparisonWidth": 16,
+    "comparisonHeight": 16,
+    "pathToDumps": "../../../Resources/VisualDumps/"
   }
 }

--- a/Aquality.Selenium/tests/Aquality.Selenium.Tests/Resources/settings.local.json
+++ b/Aquality.Selenium/tests/Aquality.Selenium.Tests/Resources/settings.local.json
@@ -103,5 +103,11 @@
   },
   "elementCache": {
     "isEnabled": false
+  },
+  "visualization": {
+    "defaultThreshold": 0.012,
+    "comparisonWidth": 16,
+    "comparisonHeight": 16,
+    "pathToDumps": "../../../Resources/VisualDumps/"
   }
 }


### PR DESCRIPTION
- update Aquality.Selenium.Core nuget package
- inherit Form from Core.Forms.Form<IElement>
- [breaking] removed [Obsolete] properties and methods from the Form abstraction
- add "visualization" section to settings.json
- add visual tests
closes #200, fixes #201 