### PR TITLE
[Feature/Enabling_Gecko_Driver_Host_Default_In_Settings] Add additional property to set geckoService.Host ::1 +semver: minor

### DIFF
--- a/Aquality.Selenium/src/Aquality.Selenium/Browsers/LocalBrowserFactory.cs
+++ b/Aquality.Selenium/src/Aquality.Selenium/Browsers/LocalBrowserFactory.cs
@@ -49,7 +49,7 @@ namespace Aquality.Selenium.Browsers
                     case BrowserName.Firefox:
                         SetUpDriver(new FirefoxConfig(), driverSettings);
                         var geckoService = FirefoxDriverService.CreateDefaultService();
-                        geckoService.Host = "::1";
+                        geckoService.Host = ((FirefoxSettings)driverSettings).IsGeckoServiceHostDefaultEnabled ? "::1" : geckoService.Host;
                         driver = GetDriver<FirefoxDriver>(geckoService, (FirefoxOptions)driverSettings.DriverOptions, commandTimeout);
                         break;
                     case BrowserName.IExplorer:

--- a/Aquality.Selenium/src/Aquality.Selenium/Browsers/LocalBrowserFactory.cs
+++ b/Aquality.Selenium/src/Aquality.Selenium/Browsers/LocalBrowserFactory.cs
@@ -24,7 +24,7 @@ namespace Aquality.Selenium.Browsers
     public class LocalBrowserFactory : BrowserFactory
     {
         private static readonly object WebDriverDownloadingLock = new object();
-        private const string HostAddress = "::1";
+        private const string HostAddressDefault = "::1";
 
         public LocalBrowserFactory(IActionRetrier actionRetrier, IBrowserProfile browserProfile, ITimeoutConfiguration timeoutConfiguration, ILocalizedLogger localizedLogger)
             : base(actionRetrier, browserProfile, timeoutConfiguration, localizedLogger)
@@ -50,7 +50,7 @@ namespace Aquality.Selenium.Browsers
                     case BrowserName.Firefox:
                         SetUpDriver(new FirefoxConfig(), driverSettings);
                         var geckoService = FirefoxDriverService.CreateDefaultService();
-                        geckoService.Host = ((FirefoxSettings)driverSettings).IsGeckoServiceHostDefaultEnabled ? HostAddress : geckoService.Host;
+                        geckoService.Host = ((FirefoxSettings)driverSettings).IsGeckoServiceHostDefaultEnabled ? HostAddressDefault : geckoService.Host;
                         driver = GetDriver<FirefoxDriver>(geckoService, (FirefoxOptions)driverSettings.DriverOptions, commandTimeout);
                         break;
                     case BrowserName.IExplorer:

--- a/Aquality.Selenium/src/Aquality.Selenium/Browsers/LocalBrowserFactory.cs
+++ b/Aquality.Selenium/src/Aquality.Selenium/Browsers/LocalBrowserFactory.cs
@@ -24,6 +24,7 @@ namespace Aquality.Selenium.Browsers
     public class LocalBrowserFactory : BrowserFactory
     {
         private static readonly object WebDriverDownloadingLock = new object();
+        private const string HostAddress = "::1";
 
         public LocalBrowserFactory(IActionRetrier actionRetrier, IBrowserProfile browserProfile, ITimeoutConfiguration timeoutConfiguration, ILocalizedLogger localizedLogger)
             : base(actionRetrier, browserProfile, timeoutConfiguration, localizedLogger)
@@ -49,7 +50,7 @@ namespace Aquality.Selenium.Browsers
                     case BrowserName.Firefox:
                         SetUpDriver(new FirefoxConfig(), driverSettings);
                         var geckoService = FirefoxDriverService.CreateDefaultService();
-                        geckoService.Host = ((FirefoxSettings)driverSettings).IsGeckoServiceHostDefaultEnabled ? "::1" : geckoService.Host;
+                        geckoService.Host = ((FirefoxSettings)driverSettings).IsGeckoServiceHostDefaultEnabled ? HostAddress : geckoService.Host;
                         driver = GetDriver<FirefoxDriver>(geckoService, (FirefoxOptions)driverSettings.DriverOptions, commandTimeout);
                         break;
                     case BrowserName.IExplorer:

--- a/Aquality.Selenium/src/Aquality.Selenium/Configurations/WebDriverSettings/FirefoxSettings.cs
+++ b/Aquality.Selenium/src/Aquality.Selenium/Configurations/WebDriverSettings/FirefoxSettings.cs
@@ -23,6 +23,8 @@ namespace Aquality.Selenium.Configurations.WebDriverSettings
 
         protected override BrowserName BrowserName => BrowserName.Firefox;
 
+        public bool IsGeckoServiceHostDefaultEnabled => SettingsFile.GetValueOrDefault($"{DriverSettingsPath}.isGeckoServiceHostDefaultEnabled", false);
+
         protected override IDictionary<string, Action<DriverOptions, object>> KnownCapabilitySetters => new Dictionary<string, Action<DriverOptions, object>>
         {
             { "binary", (options, value) => ((FirefoxOptions) options).BrowserExecutableLocation = value.ToString() },            

--- a/Aquality.Selenium/src/Aquality.Selenium/Resources/settings.json
+++ b/Aquality.Selenium/src/Aquality.Selenium/Resources/settings.json
@@ -25,6 +25,7 @@
     },
     "firefox": {
       "webDriverVersion": "Latest",
+      "isGeckoServiceHostDefaultEnabled": false,
       "capabilities": {
         "enableVNC": true,
         "unhandledPromptBehavior": "default"


### PR DESCRIPTION
Fix for starting firefox with the latest version of driver