### PR TITLE
Support Finding of Multiple elements from ShadowRoot

### DIFF
--- a/Aquality.Selenium/src/Aquality.Selenium/Aquality.Selenium.csproj
+++ b/Aquality.Selenium/src/Aquality.Selenium/Aquality.Selenium.csproj
@@ -25,6 +25,7 @@
 
   <ItemGroup>
     <None Remove="Resources\JavaScripts\ExpandShadowRoot.js" />
+    <None Remove="Resources\JavaScripts\GetElementCssSelector.js" />
     <None Remove="Resources\JavaScripts\SetAttribute.js" />
     <None Remove="Resources\Localization\be.json" />
     <None Remove="Resources\Localization\en.json" />
@@ -49,6 +50,7 @@
     <EmbeddedResource Include="Resources\JavaScripts\GetElementByXPath.js" />
     <EmbeddedResource Include="Resources\JavaScripts\ExpandShadowRoot.js" />
     <EmbeddedResource Include="Resources\JavaScripts\GetElementText.js" />
+    <EmbeddedResource Include="Resources\JavaScripts\GetElementCssSelector.js" />
     <EmbeddedResource Include="Resources\JavaScripts\GetElementXPath.js" />
     <EmbeddedResource Include="Resources\JavaScripts\GetTextFirstChild.js" />
     <EmbeddedResource Include="Resources\JavaScripts\GetViewPortCoordinates.js" />

--- a/Aquality.Selenium/src/Aquality.Selenium/Aquality.Selenium.xml
+++ b/Aquality.Selenium/src/Aquality.Selenium/Aquality.Selenium.xml
@@ -1225,6 +1225,11 @@
             </summary>
             <returns><see cref="T:OpenQA.Selenium.ShadowRoot"/> search context.</returns>
         </member>
+        <member name="P:Aquality.Selenium.Elements.Actions.JsActions.ShadowRootElementFactory">
+            <summary>
+            Provides <see cref="T:Aquality.Selenium.Elements.Interfaces.IElementFactory"/> to find elements in the shadow root of the current element.
+            </summary>
+        </member>
         <member name="M:Aquality.Selenium.Elements.Actions.JsActions.FindElementInShadowRoot``1(OpenQA.Selenium.By,System.String,Aquality.Selenium.Core.Elements.ElementSupplier{``0},Aquality.Selenium.Core.Elements.ElementState)">
             <summary>
             Finds element in the shadow root of the current element.
@@ -1237,9 +1242,23 @@
             <param name="state">State of the target element.</param>
             <returns>Instance of element.</returns>
         </member>
+        <member name="M:Aquality.Selenium.Elements.Actions.JsActions.FindElementsInShadowRoot``1(OpenQA.Selenium.By,System.String,Aquality.Selenium.Core.Elements.ElementSupplier{``0},Aquality.Selenium.Core.Elements.ElementsCount,Aquality.Selenium.Core.Elements.ElementState)">
+            <summary>
+            Finds elements in the shadow root of the current element.
+            </summary>
+            <typeparam name="T">Type of the target elements that has to implement <see cref="T:Aquality.Selenium.Elements.Interfaces.IElement"/>.</typeparam>
+            <param name="locator">Locator of target elements. 
+            Note that some browsers don't support XPath locator for shadow elements.
+            Therefore, we suggest to use CSS selectors</param>
+            <param name="name">Name of target elements.</param>
+            <param name="supplier">Delegate that defines constructor of element.</param>
+            <param name="expectedCount">Expected number of elements that have to be found (zero, more then zero, any).</param>
+            <param name="state">State of target elements.</param>
+            <returns>List of found elements.</returns>
+        </member>
         <member name="M:Aquality.Selenium.Elements.Actions.JsActions.ClickAndWait">
             <summary>
-            Perfroms click on element and waits for page is loaded.
+            Performs click on element and waits for page is loaded.
             </summary>
         </member>
         <member name="M:Aquality.Selenium.Elements.Actions.JsActions.Click">
@@ -1708,6 +1727,11 @@
             Defines base class for any UI element.
             </summary>
         </member>
+        <member name="P:Aquality.Selenium.Elements.Element.ShadowRootElementFactory">
+            <summary>
+            Provides <see cref="T:Aquality.Selenium.Elements.Interfaces.IElementFactory"/> to find elements in the shadow root of the current element.
+            </summary>
+        </member>
         <member name="T:Aquality.Selenium.Elements.ElementFactory">
             <summary>
             Factory that creates elements.
@@ -1935,11 +1959,26 @@
             </summary>
             <typeparam name="T">Type of the target element that has to implement <see cref="T:Aquality.Selenium.Elements.Interfaces.IElement"/>.</typeparam>
             <param name="locator">Locator of the target element. 
-            Note that some browsers don't support XPath locator for shadow elements.</param>
+            Note that some browsers don't support XPath locator for shadow elements. 
+            Therefore, we suggest to use CSS selectors.</param>
             <param name="name">Name of the target element.</param>
             <param name="supplier">Delegate that defines constructor of element.</param>
             <param name="state">State of the target element.</param>
             <returns>Instance of element.</returns>
+        </member>
+        <member name="M:Aquality.Selenium.Elements.Interfaces.IElement.FindElementsInShadowRoot``1(OpenQA.Selenium.By,System.String,Aquality.Selenium.Core.Elements.ElementSupplier{``0},Aquality.Selenium.Core.Elements.ElementsCount,Aquality.Selenium.Core.Elements.ElementState)">
+            <summary>
+            Finds elements in the shadow root of the current element.
+            </summary>
+            <typeparam name="T">Type of the target elements that has to implement <see cref="T:Aquality.Selenium.Elements.Interfaces.IElement"/>.</typeparam>
+            <param name="locator">Locator of target elements. 
+            Note that some browsers don't support XPath locator for shadow elements.
+            Therefore, we suggest to use CSS selectors</param>
+            <param name="name">Name of target elements.</param>
+            <param name="supplier">Delegate that defines constructor of element.</param>
+            <param name="expectedCount">Expected number of elements that have to be found (zero, more then zero, any).</param>
+            <param name="state">State of target elements.</param>
+            <returns>List of found elements.</returns>
         </member>
         <member name="T:Aquality.Selenium.Elements.Interfaces.IElementFactory">
             <summary>

--- a/Aquality.Selenium/src/Aquality.Selenium/Aquality.Selenium.xml
+++ b/Aquality.Selenium/src/Aquality.Selenium/Aquality.Selenium.xml
@@ -1225,37 +1225,6 @@
             </summary>
             <returns><see cref="T:OpenQA.Selenium.ShadowRoot"/> search context.</returns>
         </member>
-        <member name="P:Aquality.Selenium.Elements.Actions.JsActions.ShadowRootElementFactory">
-            <summary>
-            Provides <see cref="T:Aquality.Selenium.Elements.Interfaces.IElementFactory"/> to find elements in the shadow root of the current element.
-            </summary>
-        </member>
-        <member name="M:Aquality.Selenium.Elements.Actions.JsActions.FindElementInShadowRoot``1(OpenQA.Selenium.By,System.String,Aquality.Selenium.Core.Elements.ElementSupplier{``0},Aquality.Selenium.Core.Elements.ElementState)">
-            <summary>
-            Finds element in the shadow root of the current element.
-            </summary>
-            <typeparam name="T">Type of the target element that has to implement <see cref="T:Aquality.Selenium.Elements.Interfaces.IElement"/>.</typeparam>
-            <param name="locator">Locator of the target element. 
-            Note that some browsers don't support XPath locator for shadow elements (e.g. Chrome).</param>
-            <param name="name">Name of the target element.</param>
-            <param name="supplier">Delegate that defines constructor of element.</param>
-            <param name="state">State of the target element.</param>
-            <returns>Instance of element.</returns>
-        </member>
-        <member name="M:Aquality.Selenium.Elements.Actions.JsActions.FindElementsInShadowRoot``1(OpenQA.Selenium.By,System.String,Aquality.Selenium.Core.Elements.ElementSupplier{``0},Aquality.Selenium.Core.Elements.ElementsCount,Aquality.Selenium.Core.Elements.ElementState)">
-            <summary>
-            Finds elements in the shadow root of the current element.
-            </summary>
-            <typeparam name="T">Type of the target elements that has to implement <see cref="T:Aquality.Selenium.Elements.Interfaces.IElement"/>.</typeparam>
-            <param name="locator">Locator of target elements. 
-            Note that some browsers don't support XPath locator for shadow elements.
-            Therefore, we suggest to use CSS selectors</param>
-            <param name="name">Name of target elements.</param>
-            <param name="supplier">Delegate that defines constructor of element.</param>
-            <param name="expectedCount">Expected number of elements that have to be found (zero, more then zero, any).</param>
-            <param name="state">State of target elements.</param>
-            <returns>List of found elements.</returns>
-        </member>
         <member name="M:Aquality.Selenium.Elements.Actions.JsActions.ClickAndWait">
             <summary>
             Performs click on element and waits for page is loaded.
@@ -1727,11 +1696,6 @@
             Defines base class for any UI element.
             </summary>
         </member>
-        <member name="P:Aquality.Selenium.Elements.Element.ShadowRootElementFactory">
-            <summary>
-            Provides <see cref="T:Aquality.Selenium.Elements.Interfaces.IElementFactory"/> to find elements in the shadow root of the current element.
-            </summary>
-        </member>
         <member name="T:Aquality.Selenium.Elements.ElementFactory">
             <summary>
             Factory that creates elements.
@@ -1947,39 +1911,6 @@
             </summary>
             <param name="key"> Key for sending.</param>
         </member>
-        <member name="M:Aquality.Selenium.Elements.Interfaces.IElement.ExpandShadowRoot">
-            <summary>
-            Expands shadow root.
-            </summary>
-            <returns><see cref="T:OpenQA.Selenium.ShadowRoot"/> search context.</returns>
-        </member>
-        <member name="M:Aquality.Selenium.Elements.Interfaces.IElement.FindElementInShadowRoot``1(OpenQA.Selenium.By,System.String,Aquality.Selenium.Core.Elements.ElementSupplier{``0},Aquality.Selenium.Core.Elements.ElementState)">
-            <summary>
-            Finds element in the shadow root of the current element.
-            </summary>
-            <typeparam name="T">Type of the target element that has to implement <see cref="T:Aquality.Selenium.Elements.Interfaces.IElement"/>.</typeparam>
-            <param name="locator">Locator of the target element. 
-            Note that some browsers don't support XPath locator for shadow elements. 
-            Therefore, we suggest to use CSS selectors.</param>
-            <param name="name">Name of the target element.</param>
-            <param name="supplier">Delegate that defines constructor of element.</param>
-            <param name="state">State of the target element.</param>
-            <returns>Instance of element.</returns>
-        </member>
-        <member name="M:Aquality.Selenium.Elements.Interfaces.IElement.FindElementsInShadowRoot``1(OpenQA.Selenium.By,System.String,Aquality.Selenium.Core.Elements.ElementSupplier{``0},Aquality.Selenium.Core.Elements.ElementsCount,Aquality.Selenium.Core.Elements.ElementState)">
-            <summary>
-            Finds elements in the shadow root of the current element.
-            </summary>
-            <typeparam name="T">Type of the target elements that has to implement <see cref="T:Aquality.Selenium.Elements.Interfaces.IElement"/>.</typeparam>
-            <param name="locator">Locator of target elements. 
-            Note that some browsers don't support XPath locator for shadow elements.
-            Therefore, we suggest to use CSS selectors</param>
-            <param name="name">Name of target elements.</param>
-            <param name="supplier">Delegate that defines constructor of element.</param>
-            <param name="expectedCount">Expected number of elements that have to be found (zero, more then zero, any).</param>
-            <param name="state">State of target elements.</param>
-            <returns>List of found elements.</returns>
-        </member>
         <member name="T:Aquality.Selenium.Elements.Interfaces.IElementFactory">
             <summary>
             Defines the interface used to create the elements.
@@ -2085,6 +2016,55 @@
             Gets RadioButton state.
             </summary>
             <value>True if checked and false otherwise.</value>
+        </member>
+        <member name="T:Aquality.Selenium.Elements.Interfaces.IShadowRootExpander">
+            <summary>
+            Shadow Root expander.
+            </summary>
+        </member>
+        <member name="M:Aquality.Selenium.Elements.Interfaces.IShadowRootExpander.ExpandShadowRoot">
+            <summary>
+            Expands shadow root.
+            </summary>
+            <returns>ShadowRoot search context.</returns>
+        </member>
+        <member name="T:Aquality.Selenium.Elements.Interfaces.ShadowRootExpanderExtensions">
+            <summary>
+            Extensions for Shadow Root expander (like element or JS Actions).
+            </summary>
+        </member>
+        <member name="M:Aquality.Selenium.Elements.Interfaces.ShadowRootExpanderExtensions.GetShadowRootElementFactory(Aquality.Selenium.Elements.Interfaces.IShadowRootExpander)">
+            <summary>
+            Provides <see cref="T:Aquality.Selenium.Elements.Interfaces.IElementFactory"/> to find elements in the shadow root of the current element.
+            </summary>
+        </member>
+        <member name="M:Aquality.Selenium.Elements.Interfaces.ShadowRootExpanderExtensions.FindElementInShadowRoot``1(Aquality.Selenium.Elements.Interfaces.IShadowRootExpander,OpenQA.Selenium.By,System.String,Aquality.Selenium.Core.Elements.ElementSupplier{``0},Aquality.Selenium.Core.Elements.ElementState)">
+            <summary>
+            Finds element in the shadow root of the current element.
+            </summary>
+            <typeparam name="T">Type of the target element that has to implement <see cref="T:Aquality.Selenium.Elements.Interfaces.IElement"/>.</typeparam>
+            <param name="shadowRootExpander">Current instance of the Shadow root expander.</param>
+            <param name="locator">Locator of the target element. 
+            Note that some browsers don't support XPath locator for shadow elements (e.g. Chrome).</param>
+            <param name="name">Name of the target element.</param>
+            <param name="supplier">Delegate that defines constructor of element.</param>
+            <param name="state">State of the target element.</param>
+            <returns>Instance of element.</returns>
+        </member>
+        <member name="M:Aquality.Selenium.Elements.Interfaces.ShadowRootExpanderExtensions.FindElementsInShadowRoot``1(Aquality.Selenium.Elements.Interfaces.IShadowRootExpander,OpenQA.Selenium.By,System.String,Aquality.Selenium.Core.Elements.ElementSupplier{``0},Aquality.Selenium.Core.Elements.ElementsCount,Aquality.Selenium.Core.Elements.ElementState)">
+            <summary>
+            Finds elements in the shadow root of the current element.
+            </summary>
+            <typeparam name="T">Type of the target elements that has to implement <see cref="T:Aquality.Selenium.Elements.Interfaces.IElement"/>.</typeparam>
+            <param name="shadowRootExpander">Current instance of the Shadow root expander.</param>
+            <param name="locator">Locator of target elements. 
+            Note that some browsers don't support XPath locator for shadow elements.
+            Therefore, we suggest to use CSS selectors</param>
+            <param name="name">Name of target elements.</param>
+            <param name="supplier">Delegate that defines constructor of element.</param>
+            <param name="expectedCount">Expected number of elements that have to be found (zero, more then zero, any).</param>
+            <param name="state">State of target elements.</param>
+            <returns>List of found elements.</returns>
         </member>
         <member name="T:Aquality.Selenium.Elements.Interfaces.ITextBox">
             <summary>

--- a/Aquality.Selenium/src/Aquality.Selenium/Aquality.Selenium.xml
+++ b/Aquality.Selenium/src/Aquality.Selenium/Aquality.Selenium.xml
@@ -1716,6 +1716,15 @@
             </summary>
             <returns>Dictionary where key is interface and value is its implementation.</returns>
         </member>
+        <member name="M:Aquality.Selenium.Elements.ElementFactory.GenerateLocator(OpenQA.Selenium.By,OpenQA.Selenium.IWebElement,System.Int32)">
+            <summary>
+            Generates locator for target element
+            </summary>
+            <param name="baseLocator">locator of parent element</param>
+            <param name="webElement">target element</param>
+            <param name="elementIndex">index of target element</param>
+            <returns>target element's locator</returns>
+        </member>
         <member name="M:Aquality.Selenium.Elements.ElementFactory.GenerateXpathLocator(OpenQA.Selenium.By,OpenQA.Selenium.IWebElement,System.Int32)">
             <summary>
             Generates xpath locator for target element

--- a/Aquality.Selenium/src/Aquality.Selenium/Browsers/JavaScript.cs
+++ b/Aquality.Selenium/src/Aquality.Selenium/Browsers/JavaScript.cs
@@ -18,6 +18,7 @@ namespace Aquality.Selenium.Browsers
         GetElementByXPath,
         GetElementText,
         GetElementXPath,
+        GetElementCssSelector,
         GetTextFirstChild,
         IsPageLoaded,
         MouseHover,

--- a/Aquality.Selenium/src/Aquality.Selenium/Elements/Actions/JsActions.cs
+++ b/Aquality.Selenium/src/Aquality.Selenium/Elements/Actions/JsActions.cs
@@ -8,7 +8,6 @@ using Aquality.Selenium.Configurations;
 using Aquality.Selenium.Core.Elements;
 using Aquality.Selenium.Core.Localization;
 using Aquality.Selenium.Core.Utilities;
-using Aquality.Selenium.Core.Waitings;
 using Aquality.Selenium.Elements.Interfaces;
 using OpenQA.Selenium;
 
@@ -17,7 +16,7 @@ namespace Aquality.Selenium.Elements.Actions
     /// <summary>
     /// Allows to perform actions on elements via JavaScript.
     /// </summary>
-    public class JsActions
+    public class JsActions : IShadowRootExpander
     {
         private readonly IElement element;
         private readonly string elementType;
@@ -47,50 +46,16 @@ namespace Aquality.Selenium.Elements.Actions
             return ExecuteScript<ShadowRoot>(JavaScript.ExpandShadowRoot);
         }
 
-        /// <summary>
-        /// Provides <see cref="IElementFactory"/> to find elements in the shadow root of the current element.
-        /// </summary>
-        protected virtual IElementFactory ShadowRootElementFactory
-        {
-            get
-            {
-                var shadowRootRelativeFinder = new RelativeElementFinder(Logger, AqualityServices.ConditionalWait, ExpandShadowRoot);
-                return new ElementFactory(AqualityServices.ConditionalWait, shadowRootRelativeFinder, AqualityServices.Get<ILocalizationManager>());
-            }
-        }
-
-        /// <summary>
-        /// Finds element in the shadow root of the current element.
-        /// </summary>
-        /// <typeparam name="T">Type of the target element that has to implement <see cref="IElement"/>.</typeparam>
-        /// <param name="locator">Locator of the target element. 
-        /// Note that some browsers don't support XPath locator for shadow elements (e.g. Chrome).</param>
-        /// <param name="name">Name of the target element.</param>
-        /// <param name="supplier">Delegate that defines constructor of element.</param>
-        /// <param name="state">State of the target element.</param>
-        /// <returns>Instance of element.</returns>
         public T FindElementInShadowRoot<T>(By locator, string name, ElementSupplier<T> supplier = null, ElementState state = ElementState.Displayed)
             where T : IElement
         {
-            return ShadowRootElementFactory.Get(locator, name, supplier, state);
+            return this.GetShadowRootElementFactory().Get(locator, name, supplier, state);
         }
 
-        /// <summary>
-        /// Finds elements in the shadow root of the current element.
-        /// </summary>
-        /// <typeparam name="T">Type of the target elements that has to implement <see cref="IElement"/>.</typeparam>
-        /// <param name="locator">Locator of target elements. 
-        /// Note that some browsers don't support XPath locator for shadow elements.
-        /// Therefore, we suggest to use CSS selectors</param>
-        /// <param name="name">Name of target elements.</param>
-        /// <param name="supplier">Delegate that defines constructor of element.</param>
-        /// <param name="expectedCount">Expected number of elements that have to be found (zero, more then zero, any).</param>
-        /// <param name="state">State of target elements.</param>
-        /// <returns>List of found elements.</returns>
         public IList<T> FindElementsInShadowRoot<T>(By locator, string name = null, ElementSupplier<T> supplier = null, ElementsCount expectedCount = ElementsCount.Any, ElementState state = ElementState.Displayed)
             where T : IElement
         {
-            return ShadowRootElementFactory.FindElements(locator, name, supplier, expectedCount, state);
+            return this.GetShadowRootElementFactory().FindElements(locator, name, supplier, expectedCount, state);
         }
 
         /// <summary>

--- a/Aquality.Selenium/src/Aquality.Selenium/Elements/Actions/JsActions.cs
+++ b/Aquality.Selenium/src/Aquality.Selenium/Elements/Actions/JsActions.cs
@@ -5,7 +5,6 @@ using System.Drawing;
 using System.Linq;
 using Aquality.Selenium.Browsers;
 using Aquality.Selenium.Configurations;
-using Aquality.Selenium.Core.Elements;
 using Aquality.Selenium.Core.Localization;
 using Aquality.Selenium.Core.Utilities;
 using Aquality.Selenium.Elements.Interfaces;
@@ -44,18 +43,6 @@ namespace Aquality.Selenium.Elements.Actions
         {
             LogElementAction("loc.shadowroot.expand.js");
             return ExecuteScript<ShadowRoot>(JavaScript.ExpandShadowRoot);
-        }
-
-        public T FindElementInShadowRoot<T>(By locator, string name, ElementSupplier<T> supplier = null, ElementState state = ElementState.Displayed)
-            where T : IElement
-        {
-            return this.GetShadowRootElementFactory().Get(locator, name, supplier, state);
-        }
-
-        public IList<T> FindElementsInShadowRoot<T>(By locator, string name = null, ElementSupplier<T> supplier = null, ElementsCount expectedCount = ElementsCount.Any, ElementState state = ElementState.Displayed)
-            where T : IElement
-        {
-            return this.GetShadowRootElementFactory().FindElements(locator, name, supplier, expectedCount, state);
         }
 
         /// <summary>

--- a/Aquality.Selenium/src/Aquality.Selenium/Elements/Actions/JsActions.cs
+++ b/Aquality.Selenium/src/Aquality.Selenium/Elements/Actions/JsActions.cs
@@ -8,6 +8,7 @@ using Aquality.Selenium.Configurations;
 using Aquality.Selenium.Core.Elements;
 using Aquality.Selenium.Core.Localization;
 using Aquality.Selenium.Core.Utilities;
+using Aquality.Selenium.Core.Waitings;
 using Aquality.Selenium.Elements.Interfaces;
 using OpenQA.Selenium;
 
@@ -47,6 +48,18 @@ namespace Aquality.Selenium.Elements.Actions
         }
 
         /// <summary>
+        /// Provides <see cref="IElementFactory"/> to find elements in the shadow root of the current element.
+        /// </summary>
+        protected virtual IElementFactory ShadowRootElementFactory
+        {
+            get
+            {
+                var shadowRootRelativeFinder = new RelativeElementFinder(Logger, AqualityServices.ConditionalWait, ExpandShadowRoot);
+                return new ElementFactory(AqualityServices.ConditionalWait, shadowRootRelativeFinder, AqualityServices.Get<ILocalizationManager>());
+            }
+        }
+
+        /// <summary>
         /// Finds element in the shadow root of the current element.
         /// </summary>
         /// <typeparam name="T">Type of the target element that has to implement <see cref="IElement"/>.</typeparam>
@@ -59,13 +72,29 @@ namespace Aquality.Selenium.Elements.Actions
         public T FindElementInShadowRoot<T>(By locator, string name, ElementSupplier<T> supplier = null, ElementState state = ElementState.Displayed)
             where T : IElement
         {
-            var shadowRootRelativeFinder = new RelativeElementFinder(Logger, AqualityServices.ConditionalWait, ExpandShadowRoot);
-            var shadowRootFactory = new ElementFactory(AqualityServices.ConditionalWait, shadowRootRelativeFinder, AqualityServices.Get<ILocalizationManager>());
-            return shadowRootFactory.Get(locator, name, supplier, state);
+            return ShadowRootElementFactory.Get(locator, name, supplier, state);
         }
 
         /// <summary>
-        /// Perfroms click on element and waits for page is loaded.
+        /// Finds elements in the shadow root of the current element.
+        /// </summary>
+        /// <typeparam name="T">Type of the target elements that has to implement <see cref="IElement"/>.</typeparam>
+        /// <param name="locator">Locator of target elements. 
+        /// Note that some browsers don't support XPath locator for shadow elements.
+        /// Therefore, we suggest to use CSS selectors</param>
+        /// <param name="name">Name of target elements.</param>
+        /// <param name="supplier">Delegate that defines constructor of element.</param>
+        /// <param name="expectedCount">Expected number of elements that have to be found (zero, more then zero, any).</param>
+        /// <param name="state">State of target elements.</param>
+        /// <returns>List of found elements.</returns>
+        public IList<T> FindElementsInShadowRoot<T>(By locator, string name = null, ElementSupplier<T> supplier = null, ElementsCount expectedCount = ElementsCount.Any, ElementState state = ElementState.Displayed)
+            where T : IElement
+        {
+            return ShadowRootElementFactory.FindElements(locator, name, supplier, expectedCount, state);
+        }
+
+        /// <summary>
+        /// Performs click on element and waits for page is loaded.
         /// </summary>
         public void ClickAndWait()
         {

--- a/Aquality.Selenium/src/Aquality.Selenium/Elements/Element.cs
+++ b/Aquality.Selenium/src/Aquality.Selenium/Elements/Element.cs
@@ -16,6 +16,7 @@ using CoreElement = Aquality.Selenium.Core.Elements.Element;
 using ICoreElementFactory = Aquality.Selenium.Core.Elements.Interfaces.IElementFactory;
 using ICoreElementFinder = Aquality.Selenium.Core.Elements.Interfaces.IElementFinder;
 using ICoreElementStateProvider = Aquality.Selenium.Core.Elements.Interfaces.IElementStateProvider;
+using System.Collections.Generic;
 
 namespace Aquality.Selenium.Elements
 {
@@ -135,12 +136,28 @@ namespace Aquality.Selenium.Elements
             return shadowRoot;
         }
 
+        /// <summary>
+        /// Provides <see cref="IElementFactory"/> to find elements in the shadow root of the current element.
+        /// </summary>
+        protected virtual IElementFactory ShadowRootElementFactory
+        {
+            get
+            {
+                var shadowRootRelativeFinder = new RelativeElementFinder(LocalizedLogger, ConditionalWait, ExpandShadowRoot);
+                return new ElementFactory(ConditionalWait, shadowRootRelativeFinder, LocalizationManager);
+            }
+        }
+
         public T FindElementInShadowRoot<T>(By locator, string name, ElementSupplier<T> supplier = null, ElementState state = ElementState.Displayed) 
             where T : IElement
         {
-            var shadowRootRelativeFinder = new RelativeElementFinder(LocalizedLogger, ConditionalWait, ExpandShadowRoot);
-            var shadowRootFactory = new ElementFactory(ConditionalWait, shadowRootRelativeFinder, LocalizationManager);
-            return shadowRootFactory.Get(locator, name, supplier, state);
+            return ShadowRootElementFactory.Get(locator, name, supplier, state);
+        }
+
+        public IList<T> FindElementsInShadowRoot<T>(By locator, string name = null, ElementSupplier<T> supplier = null, ElementsCount expectedCount = ElementsCount.Any, ElementState state = ElementState.Displayed) 
+            where T : IElement
+        {
+            return ShadowRootElementFactory.FindElements(locator, name, supplier, expectedCount, state);
         }
     }
 }

--- a/Aquality.Selenium/src/Aquality.Selenium/Elements/Element.cs
+++ b/Aquality.Selenium/src/Aquality.Selenium/Elements/Element.cs
@@ -135,17 +135,5 @@ namespace Aquality.Selenium.Elements
             var shadowRoot = (ShadowRoot)GetElement().GetShadowRoot();
             return shadowRoot;
         }
-
-        public T FindElementInShadowRoot<T>(By locator, string name, ElementSupplier<T> supplier = null, ElementState state = ElementState.Displayed) 
-            where T : IElement
-        {
-            return this.GetShadowRootElementFactory().Get(locator, name, supplier, state);
-        }
-
-        public IList<T> FindElementsInShadowRoot<T>(By locator, string name = null, ElementSupplier<T> supplier = null, ElementsCount expectedCount = ElementsCount.Any, ElementState state = ElementState.Displayed) 
-            where T : IElement
-        {
-            return this.GetShadowRootElementFactory().FindElements(locator, name, supplier, expectedCount, state);
-        }
     }
 }

--- a/Aquality.Selenium/src/Aquality.Selenium/Elements/Element.cs
+++ b/Aquality.Selenium/src/Aquality.Selenium/Elements/Element.cs
@@ -136,28 +136,16 @@ namespace Aquality.Selenium.Elements
             return shadowRoot;
         }
 
-        /// <summary>
-        /// Provides <see cref="IElementFactory"/> to find elements in the shadow root of the current element.
-        /// </summary>
-        protected virtual IElementFactory ShadowRootElementFactory
-        {
-            get
-            {
-                var shadowRootRelativeFinder = new RelativeElementFinder(LocalizedLogger, ConditionalWait, ExpandShadowRoot);
-                return new ElementFactory(ConditionalWait, shadowRootRelativeFinder, LocalizationManager);
-            }
-        }
-
         public T FindElementInShadowRoot<T>(By locator, string name, ElementSupplier<T> supplier = null, ElementState state = ElementState.Displayed) 
             where T : IElement
         {
-            return ShadowRootElementFactory.Get(locator, name, supplier, state);
+            return this.GetShadowRootElementFactory().Get(locator, name, supplier, state);
         }
 
         public IList<T> FindElementsInShadowRoot<T>(By locator, string name = null, ElementSupplier<T> supplier = null, ElementsCount expectedCount = ElementsCount.Any, ElementState state = ElementState.Displayed) 
             where T : IElement
         {
-            return ShadowRootElementFactory.FindElements(locator, name, supplier, expectedCount, state);
+            return this.GetShadowRootElementFactory().FindElements(locator, name, supplier, expectedCount, state);
         }
     }
 }

--- a/Aquality.Selenium/src/Aquality.Selenium/Elements/ElementFactory.cs
+++ b/Aquality.Selenium/src/Aquality.Selenium/Elements/ElementFactory.cs
@@ -122,16 +122,20 @@ namespace Aquality.Selenium.Elements
         /// <returns>target element's locator</returns>
         protected override By GenerateXpathLocator(By baseLocator, IWebElement webElement, int elementIndex)
         {
-            if (IsLocatorSupportedForXPathExtraction(baseLocator))
-            {
-                return base.GenerateXpathLocator(baseLocator, webElement, elementIndex);
-            }
             try
             {
+                if (IsLocatorSupportedForXPathExtraction(baseLocator))
+                {
+                    var locator = base.GenerateXpathLocator(baseLocator, webElement, elementIndex);
+                    if (ElementFinder.FindElements(locator).Count == 1)
+                    {
+                        return locator;
+                    }
+                }
                 return By.XPath(ConditionalWait.WaitFor(driver => driver.ExecuteJavaScript<string>(
                     JavaScript.GetElementXPath.GetScript(), webElement), message: "XPath generation failed"));
             }
-            catch (Exception ex)
+            catch (WebDriverException ex)
             {
                 return By.CssSelector(ConditionalWait.WaitFor(driver => driver.ExecuteJavaScript<string>(
                     JavaScript.GetElementCssSelector.GetScript(), webElement), message: $"{ex.Message}. CSS selector generation failed too."));

--- a/Aquality.Selenium/src/Aquality.Selenium/Elements/ElementFactory.cs
+++ b/Aquality.Selenium/src/Aquality.Selenium/Elements/ElementFactory.cs
@@ -114,6 +114,26 @@ namespace Aquality.Selenium.Elements
         }
 
         /// <summary>
+        /// Generates locator for target element
+        /// </summary>
+        /// <param name="baseLocator">locator of parent element</param>
+        /// <param name="webElement">target element</param>
+        /// <param name="elementIndex">index of target element</param>
+        /// <returns>target element's locator</returns>
+        protected override By GenerateLocator(By baseLocator, IWebElement webElement, int elementIndex)
+        {
+            try
+            {
+                return GenerateXpathLocator(baseLocator, webElement, elementIndex);
+            }
+            catch (WebDriverException ex)
+            {
+                return By.CssSelector(ConditionalWait.WaitFor(driver => driver.ExecuteJavaScript<string>(
+                    JavaScript.GetElementCssSelector.GetScript(), webElement), message: $"{ex.Message}. CSS selector generation failed too."));
+            }
+        }
+
+        /// <summary>
         /// Generates xpath locator for target element
         /// </summary>
         /// <param name="baseLocator">locator of parent element</param>
@@ -122,24 +142,16 @@ namespace Aquality.Selenium.Elements
         /// <returns>target element's locator</returns>
         protected override By GenerateXpathLocator(By baseLocator, IWebElement webElement, int elementIndex)
         {
-            try
+            if (IsLocatorSupportedForXPathExtraction(baseLocator))
             {
-                if (IsLocatorSupportedForXPathExtraction(baseLocator))
+                var locator = base.GenerateXpathLocator(baseLocator, webElement, elementIndex);
+                if (ElementFinder.FindElements(locator).Count == 1)
                 {
-                    var locator = base.GenerateXpathLocator(baseLocator, webElement, elementIndex);
-                    if (ElementFinder.FindElements(locator).Count == 1)
-                    {
-                        return locator;
-                    }
+                    return locator;
                 }
-                return By.XPath(ConditionalWait.WaitFor(driver => driver.ExecuteJavaScript<string>(
-                    JavaScript.GetElementXPath.GetScript(), webElement), message: "XPath generation failed"));
             }
-            catch (WebDriverException ex)
-            {
-                return By.CssSelector(ConditionalWait.WaitFor(driver => driver.ExecuteJavaScript<string>(
-                    JavaScript.GetElementCssSelector.GetScript(), webElement), message: $"{ex.Message}. CSS selector generation failed too."));
-            }                
+            return By.XPath(ConditionalWait.WaitFor(driver => driver.ExecuteJavaScript<string>(
+                JavaScript.GetElementXPath.GetScript(), webElement), message: "XPath generation failed"));
         }
 
         /// <summary>

--- a/Aquality.Selenium/src/Aquality.Selenium/Elements/ElementFactory.cs
+++ b/Aquality.Selenium/src/Aquality.Selenium/Elements/ElementFactory.cs
@@ -122,10 +122,20 @@ namespace Aquality.Selenium.Elements
         /// <returns>target element's locator</returns>
         protected override By GenerateXpathLocator(By baseLocator, IWebElement webElement, int elementIndex)
         {
-            return IsLocatorSupportedForXPathExtraction(baseLocator)
-                ? base.GenerateXpathLocator(baseLocator, webElement, elementIndex)
-                : By.XPath(ConditionalWait.WaitFor(driver => driver.ExecuteJavaScript<string>(
+            if (IsLocatorSupportedForXPathExtraction(baseLocator))
+            {
+                return base.GenerateXpathLocator(baseLocator, webElement, elementIndex);
+            }
+            try
+            {
+                return By.XPath(ConditionalWait.WaitFor(driver => driver.ExecuteJavaScript<string>(
                     JavaScript.GetElementXPath.GetScript(), webElement), message: "XPath generation failed"));
+            }
+            catch (Exception ex)
+            {
+                return By.CssSelector(ConditionalWait.WaitFor(driver => driver.ExecuteJavaScript<string>(
+                    JavaScript.GetElementCssSelector.GetScript(), webElement), message: $"{ex.Message}. CSS selector generation failed too."));
+            }                
         }
 
         /// <summary>

--- a/Aquality.Selenium/src/Aquality.Selenium/Elements/Interfaces/IElement.cs
+++ b/Aquality.Selenium/src/Aquality.Selenium/Elements/Interfaces/IElement.cs
@@ -1,7 +1,4 @@
-﻿using Aquality.Selenium.Core.Elements;
-using Aquality.Selenium.Elements.Actions;
-using OpenQA.Selenium;
-using System.Collections.Generic;
+﻿using Aquality.Selenium.Elements.Actions;
 using ICoreElement = Aquality.Selenium.Core.Elements.Interfaces.IElement;
 
 namespace Aquality.Selenium.Elements.Interfaces
@@ -9,7 +6,7 @@ namespace Aquality.Selenium.Elements.Interfaces
     /// <summary>
     /// Describes behavior of any UI element.
     /// </summary>
-    public interface IElement : ICoreElement
+    public interface IElement : ICoreElement, IShadowRootExpander
     {
         /// <summary>
         /// Gets JavaScript actions that can be performed with an element.
@@ -75,40 +72,5 @@ namespace Aquality.Selenium.Elements.Interfaces
         /// </summary>
         /// <param name="key"> Key for sending.</param>
         void SendKey(Key key);
-
-        /// <summary>
-        /// Expands shadow root.
-        /// </summary>
-        /// <returns><see cref="ShadowRoot"/> search context.</returns>
-        ShadowRoot ExpandShadowRoot();
-
-        /// <summary>
-        /// Finds element in the shadow root of the current element.
-        /// </summary>
-        /// <typeparam name="T">Type of the target element that has to implement <see cref="IElement"/>.</typeparam>
-        /// <param name="locator">Locator of the target element. 
-        /// Note that some browsers don't support XPath locator for shadow elements. 
-        /// Therefore, we suggest to use CSS selectors.</param>
-        /// <param name="name">Name of the target element.</param>
-        /// <param name="supplier">Delegate that defines constructor of element.</param>
-        /// <param name="state">State of the target element.</param>
-        /// <returns>Instance of element.</returns>
-        T FindElementInShadowRoot<T>(By locator, string name, ElementSupplier<T> supplier = null, ElementState state = ElementState.Displayed) 
-            where T : IElement;
-
-        /// <summary>
-        /// Finds elements in the shadow root of the current element.
-        /// </summary>
-        /// <typeparam name="T">Type of the target elements that has to implement <see cref="IElement"/>.</typeparam>
-        /// <param name="locator">Locator of target elements. 
-        /// Note that some browsers don't support XPath locator for shadow elements.
-        /// Therefore, we suggest to use CSS selectors</param>
-        /// <param name="name">Name of target elements.</param>
-        /// <param name="supplier">Delegate that defines constructor of element.</param>
-        /// <param name="expectedCount">Expected number of elements that have to be found (zero, more then zero, any).</param>
-        /// <param name="state">State of target elements.</param>
-        /// <returns>List of found elements.</returns>
-        IList<T> FindElementsInShadowRoot<T>(By locator, string name = null, ElementSupplier<T> supplier = null, ElementsCount expectedCount = ElementsCount.Any, ElementState state = ElementState.Displayed) 
-            where T : IElement;
     }
 }

--- a/Aquality.Selenium/src/Aquality.Selenium/Elements/Interfaces/IElement.cs
+++ b/Aquality.Selenium/src/Aquality.Selenium/Elements/Interfaces/IElement.cs
@@ -1,6 +1,7 @@
 ﻿using Aquality.Selenium.Core.Elements;
 using Aquality.Selenium.Elements.Actions;
 using OpenQA.Selenium;
+using System.Collections.Generic;
 using ICoreElement = Aquality.Selenium.Core.Elements.Interfaces.IElement;
 
 namespace Aquality.Selenium.Elements.Interfaces
@@ -86,12 +87,28 @@ namespace Aquality.Selenium.Elements.Interfaces
         /// </summary>
         /// <typeparam name="T">Type of the target element that has to implement <see cref="IElement"/>.</typeparam>
         /// <param name="locator">Locator of the target element. 
-        /// Note that some browsers don't support XPath locator for shadow elements.</param>
+        /// Note that some browsers don't support XPath locator for shadow elements. 
+        /// Therefore, we suggest to use CSS selectors.</param>
         /// <param name="name">Name of the target element.</param>
         /// <param name="supplier">Delegate that defines constructor of element.</param>
         /// <param name="state">State of the target element.</param>
         /// <returns>Instance of element.</returns>
         T FindElementInShadowRoot<T>(By locator, string name, ElementSupplier<T> supplier = null, ElementState state = ElementState.Displayed) 
+            where T : IElement;
+
+        /// <summary>
+        /// Finds elements in the shadow root of the current element.
+        /// </summary>
+        /// <typeparam name="T">Type of the target elements that has to implement <see cref="IElement"/>.</typeparam>
+        /// <param name="locator">Locator of target elements. 
+        /// Note that some browsers don't support XPath locator for shadow elements.
+        /// Therefore, we suggest to use CSS selectors</param>
+        /// <param name="name">Name of target elements.</param>
+        /// <param name="supplier">Delegate that defines constructor of element.</param>
+        /// <param name="expectedCount">Expected number of elements that have to be found (zero, more then zero, any).</param>
+        /// <param name="state">State of target elements.</param>
+        /// <returns>List of found elements.</returns>
+        IList<T> FindElementsInShadowRoot<T>(By locator, string name = null, ElementSupplier<T> supplier = null, ElementsCount expectedCount = ElementsCount.Any, ElementState state = ElementState.Displayed) 
             where T : IElement;
     }
 }

--- a/Aquality.Selenium/src/Aquality.Selenium/Elements/Interfaces/IShadowRootExpander.cs
+++ b/Aquality.Selenium/src/Aquality.Selenium/Elements/Interfaces/IShadowRootExpander.cs
@@ -1,0 +1,63 @@
+﻿using Aquality.Selenium.Browsers;
+using Aquality.Selenium.Core.Elements;
+using Aquality.Selenium.Core.Localization;
+using OpenQA.Selenium;
+using System.Collections.Generic;
+
+namespace Aquality.Selenium.Elements.Interfaces
+{
+    /// <summary>
+    /// Shadow Root expander.
+    /// </summary>
+    public interface IShadowRootExpander
+    {
+        /// <summary>
+        /// Expands shadow root.
+        /// </summary>
+        /// <returns>ShadowRoot search context.</returns>
+        ShadowRoot ExpandShadowRoot();
+
+        /// <summary>
+        /// Finds element in the shadow root of the current element.
+        /// </summary>
+        /// <typeparam name="T">Type of the target element that has to implement <see cref="IElement"/>.</typeparam>
+        /// <param name="locator">Locator of the target element. 
+        /// Note that some browsers don't support XPath locator for shadow elements (e.g. Chrome).</param>
+        /// <param name="name">Name of the target element.</param>
+        /// <param name="supplier">Delegate that defines constructor of element.</param>
+        /// <param name="state">State of the target element.</param>
+        /// <returns>Instance of element.</returns>
+        T FindElementInShadowRoot<T>(By locator, string name, ElementSupplier<T> supplier = null, ElementState state = ElementState.Displayed)
+            where T : IElement;
+
+        /// <summary>
+        /// Finds elements in the shadow root of the current element.
+        /// </summary>
+        /// <typeparam name="T">Type of the target elements that has to implement <see cref="IElement"/>.</typeparam>
+        /// <param name="locator">Locator of target elements. 
+        /// Note that some browsers don't support XPath locator for shadow elements.
+        /// Therefore, we suggest to use CSS selectors</param>
+        /// <param name="name">Name of target elements.</param>
+        /// <param name="supplier">Delegate that defines constructor of element.</param>
+        /// <param name="expectedCount">Expected number of elements that have to be found (zero, more then zero, any).</param>
+        /// <param name="state">State of target elements.</param>
+        /// <returns>List of found elements.</returns>
+        IList<T> FindElementsInShadowRoot<T>(By locator, string name = null, ElementSupplier<T> supplier = null, ElementsCount expectedCount = ElementsCount.Any, ElementState state = ElementState.Displayed)
+            where T : IElement;
+    }
+
+    /// <summary>
+    /// Extensions for Shadow Root expander.
+    /// </summary>
+    public static class ShadowRootExpanderExtensions
+    {
+        /// <summary>
+        /// Provides <see cref="IElementFactory"/> to find elements in the shadow root of the current element.
+        /// </summary>
+        public static IElementFactory GetShadowRootElementFactory(this IShadowRootExpander shadowRootExpander)
+        {
+            var shadowRootRelativeFinder = new RelativeElementFinder(AqualityServices.LocalizedLogger, AqualityServices.ConditionalWait, shadowRootExpander.ExpandShadowRoot);
+            return new ElementFactory(AqualityServices.ConditionalWait, shadowRootRelativeFinder, AqualityServices.Get<ILocalizationManager>());        
+        }
+    }
+}

--- a/Aquality.Selenium/src/Aquality.Selenium/Elements/Interfaces/IShadowRootExpander.cs
+++ b/Aquality.Selenium/src/Aquality.Selenium/Elements/Interfaces/IShadowRootExpander.cs
@@ -16,38 +16,10 @@ namespace Aquality.Selenium.Elements.Interfaces
         /// </summary>
         /// <returns>ShadowRoot search context.</returns>
         ShadowRoot ExpandShadowRoot();
-
-        /// <summary>
-        /// Finds element in the shadow root of the current element.
-        /// </summary>
-        /// <typeparam name="T">Type of the target element that has to implement <see cref="IElement"/>.</typeparam>
-        /// <param name="locator">Locator of the target element. 
-        /// Note that some browsers don't support XPath locator for shadow elements (e.g. Chrome).</param>
-        /// <param name="name">Name of the target element.</param>
-        /// <param name="supplier">Delegate that defines constructor of element.</param>
-        /// <param name="state">State of the target element.</param>
-        /// <returns>Instance of element.</returns>
-        T FindElementInShadowRoot<T>(By locator, string name, ElementSupplier<T> supplier = null, ElementState state = ElementState.Displayed)
-            where T : IElement;
-
-        /// <summary>
-        /// Finds elements in the shadow root of the current element.
-        /// </summary>
-        /// <typeparam name="T">Type of the target elements that has to implement <see cref="IElement"/>.</typeparam>
-        /// <param name="locator">Locator of target elements. 
-        /// Note that some browsers don't support XPath locator for shadow elements.
-        /// Therefore, we suggest to use CSS selectors</param>
-        /// <param name="name">Name of target elements.</param>
-        /// <param name="supplier">Delegate that defines constructor of element.</param>
-        /// <param name="expectedCount">Expected number of elements that have to be found (zero, more then zero, any).</param>
-        /// <param name="state">State of target elements.</param>
-        /// <returns>List of found elements.</returns>
-        IList<T> FindElementsInShadowRoot<T>(By locator, string name = null, ElementSupplier<T> supplier = null, ElementsCount expectedCount = ElementsCount.Any, ElementState state = ElementState.Displayed)
-            where T : IElement;
     }
 
     /// <summary>
-    /// Extensions for Shadow Root expander.
+    /// Extensions for Shadow Root expander (like element or JS Actions).
     /// </summary>
     public static class ShadowRootExpanderExtensions
     {
@@ -57,7 +29,43 @@ namespace Aquality.Selenium.Elements.Interfaces
         public static IElementFactory GetShadowRootElementFactory(this IShadowRootExpander shadowRootExpander)
         {
             var shadowRootRelativeFinder = new RelativeElementFinder(AqualityServices.LocalizedLogger, AqualityServices.ConditionalWait, shadowRootExpander.ExpandShadowRoot);
-            return new ElementFactory(AqualityServices.ConditionalWait, shadowRootRelativeFinder, AqualityServices.Get<ILocalizationManager>());        
+            return new ElementFactory(AqualityServices.ConditionalWait, shadowRootRelativeFinder, AqualityServices.Get<ILocalizationManager>());
+        }
+
+        /// <summary>
+        /// Finds element in the shadow root of the current element.
+        /// </summary>
+        /// <typeparam name="T">Type of the target element that has to implement <see cref="IElement"/>.</typeparam>
+        /// <param name="shadowRootExpander">Current instance of the Shadow root expander.</param>
+        /// <param name="locator">Locator of the target element. 
+        /// Note that some browsers don't support XPath locator for shadow elements (e.g. Chrome).</param>
+        /// <param name="name">Name of the target element.</param>
+        /// <param name="supplier">Delegate that defines constructor of element.</param>
+        /// <param name="state">State of the target element.</param>
+        /// <returns>Instance of element.</returns>
+        public static T FindElementInShadowRoot<T>(this IShadowRootExpander shadowRootExpander, By locator, string name, ElementSupplier<T> supplier = null, ElementState state = ElementState.Displayed)
+            where T : IElement
+        {
+            return shadowRootExpander.GetShadowRootElementFactory().Get(locator, name, supplier, state);
+        }
+
+        /// <summary>
+        /// Finds elements in the shadow root of the current element.
+        /// </summary>
+        /// <typeparam name="T">Type of the target elements that has to implement <see cref="IElement"/>.</typeparam>
+        /// <param name="shadowRootExpander">Current instance of the Shadow root expander.</param>
+        /// <param name="locator">Locator of target elements. 
+        /// Note that some browsers don't support XPath locator for shadow elements.
+        /// Therefore, we suggest to use CSS selectors</param>
+        /// <param name="name">Name of target elements.</param>
+        /// <param name="supplier">Delegate that defines constructor of element.</param>
+        /// <param name="expectedCount">Expected number of elements that have to be found (zero, more then zero, any).</param>
+        /// <param name="state">State of target elements.</param>
+        /// <returns>List of found elements.</returns>
+        public static IList<T> FindElementsInShadowRoot<T>(this IShadowRootExpander shadowRootExpander, By locator, string name = null, ElementSupplier<T> supplier = null, ElementsCount expectedCount = ElementsCount.Any, ElementState state = ElementState.Displayed)
+            where T : IElement
+        {
+            return shadowRootExpander.GetShadowRootElementFactory().FindElements(locator, name, supplier, expectedCount, state);
         }
     }
 }

--- a/Aquality.Selenium/src/Aquality.Selenium/Resources/JavaScripts/GetElementCssSelector.js
+++ b/Aquality.Selenium/src/Aquality.Selenium/Resources/JavaScripts/GetElementCssSelector.js
@@ -11,8 +11,8 @@ function previousElementSibling (element) {
   }
 }
 function getCssPath (element) {
-  // False on non-elements
-  if (!(element instanceof HTMLElement)) { return false; }
+  // Empty on non-elements
+  if (!(element instanceof HTMLElement)) { return ''; }
   let path = [];
   while (element.nodeType === Node.ELEMENT_NODE) {
     let selector = element.nodeName;

--- a/Aquality.Selenium/src/Aquality.Selenium/Resources/JavaScripts/GetElementCssSelector.js
+++ b/Aquality.Selenium/src/Aquality.Selenium/Resources/JavaScripts/GetElementCssSelector.js
@@ -1,0 +1,23 @@
+function getCssPath(element) {
+    const selectorPath = [];
+
+    while (element.tagName) {
+        let selector = element.nodeName.toLowerCase();
+        if (element.id) {
+            selector += `#${element.id}`;
+        } else if (element.parentNode) {
+            let i = 0;
+            const children = element.parentNode.children;
+            while (i < children.length && children[i] !== element) {
+                i++;
+            }
+            selector += `:nth-child(${i + 1})`
+        }
+
+        selectorPath.unshift(selector);
+        element = element.parentNode;
+    }
+
+    return selectorPath.join(' > ');
+}
+return getCssPath(arguments[0]);

--- a/Aquality.Selenium/src/Aquality.Selenium/Resources/JavaScripts/GetElementCssSelector.js
+++ b/Aquality.Selenium/src/Aquality.Selenium/Resources/JavaScripts/GetElementCssSelector.js
@@ -1,23 +1,40 @@
-function getCssPath(element) {
-    const selectorPath = [];
-
-    while (element.tagName) {
-        let selector = element.nodeName.toLowerCase();
-        if (element.id) {
-            selector += `#${element.id}`;
-        } else if (element.parentNode) {
-            let i = 0;
-            const children = element.parentNode.children;
-            while (i < children.length && children[i] !== element) {
-                i++;
-            }
-            selector += `:nth-child(${i + 1})`
-        }
-
-        selectorPath.unshift(selector);
-        element = element.parentNode;
+function previousElementSibling (element) {
+  if (element.previousElementSibling !== 'undefined') {
+    return element.previousElementSibling;
+  } else {
+    // Loop through ignoring anything not an element
+    while (element = element.previousSibling) {
+      if (element.nodeType === 1) {
+        return element;
+      }
     }
-
-    return selectorPath.join(' > ');
+  }
+}
+function getCssPath (element) {
+  // False on non-elements
+  if (!(element instanceof HTMLElement)) { return false; }
+  let path = [];
+  while (element.nodeType === Node.ELEMENT_NODE) {
+    let selector = element.nodeName;
+    if (element.id) { selector += ('#' + element.id); }
+    else {
+      // Walk backwards until there is no previous sibling
+      let sibling = element;
+      // Will hold nodeName to join for adjacent selection
+      let siblingSelectors = [];
+      while (sibling !== null && sibling.nodeType === Node.ELEMENT_NODE) {
+        siblingSelectors.unshift(sibling.nodeName);
+        sibling = previousElementSibling(sibling);
+      }
+      // :first-child does not apply to HTML
+      if (siblingSelectors[0] !== 'HTML') {
+        siblingSelectors[0] = siblingSelectors[0] + ':first-child';
+      }
+      selector = siblingSelectors.join(' + ');
+    }
+    path.unshift(selector);
+    element = element.parentNode;
+  }
+  return path.join(' > ');
 }
 return getCssPath(arguments[0]);

--- a/Aquality.Selenium/tests/Aquality.Selenium.Tests/Integration/ShadowRootTests.cs
+++ b/Aquality.Selenium/tests/Aquality.Selenium.Tests/Integration/ShadowRootTests.cs
@@ -1,6 +1,7 @@
 ﻿using Aquality.Selenium.Elements.Interfaces;
 using Aquality.Selenium.Tests.Integration.TestApp.Browser.Forms;
 using NUnit.Framework;
+using System.Linq;
 
 namespace Aquality.Selenium.Tests.Integration
 {
@@ -19,8 +20,13 @@ namespace Aquality.Selenium.Tests.Integration
         {
             Assert.IsNotNull(form.ExpandShadowRoot(), "Should be possible to expand shadow root and get Selenium native ShadowRoot object");            
             Assert.IsNotNull(form.DownloadsToolbarLabel.GetElement(), "Should be possible do get the element hidden under the shadow");
+            var elementLabels = form.DivElementLabels;
+            Assert.That(elementLabels, Has.Count.GreaterThan(1), "Should be possible to find multiple elements hidden under the shadow");
+            Assert.That(elementLabels.First().Locator.Mechanism, Contains.Substring("css"), "Unique locator of correct type should be generated");
+            Assert.That(elementLabels.First().GetElement().TagName, Is.EqualTo("div"), "Should be possible to work with one of found elements");
             Assert.IsNotNull(form.DownloadsToolbarLabel.FindElementInShadowRoot<ILabel>(ChromeDownloadsForm.NestedShadowRootLocator, "More actions menu").GetElement(),
                 "Should be possible to expand the nested shadow root and get the element from it");
+            
             Assert.IsTrue(form.MainContainerLabel.State.IsDisplayed, "Should be possible to check that element under the shadow is displayed");
         }
 
@@ -29,6 +35,10 @@ namespace Aquality.Selenium.Tests.Integration
         {
             Assert.IsNotNull(form.ExpandShadowRootViaJs(), "Should be possible to expand shadow root and get Selenium native ShadowRoot object");
             Assert.IsNotNull(form.DownloadsToolbarLabelFromJs.GetElement(), "Should be possible do get the element hidden under the shadow");
+            var elementLabels = form.DivElementLabelsFromJs;
+            Assert.That(elementLabels, Has.Count.GreaterThan(1), "Should be possible to find multiple elements hidden under the shadow");
+            Assert.That(elementLabels.First().Locator.Mechanism, Contains.Substring("css"), "Unique locator of correct type should be generated");
+            Assert.That(elementLabels.First().GetElement().TagName, Is.EqualTo("div"), "Should be possible to work with one of found elements");
             Assert.IsNotNull(form.DownloadsToolbarLabelFromJs.JsActions.FindElementInShadowRoot<ILabel>(ChromeDownloadsForm.NestedShadowRootLocator, "More actions menu").GetElement(),
                 "Should be possible to expand the nested shadow root and get the element from it");
             Assert.IsTrue(form.MainContainerLabelFromJs.State.IsDisplayed, "Should be possible to check that element under the shadow is displayed");

--- a/Aquality.Selenium/tests/Aquality.Selenium.Tests/Integration/ShadowRootTests.cs
+++ b/Aquality.Selenium/tests/Aquality.Selenium.Tests/Integration/ShadowRootTests.cs
@@ -18,16 +18,26 @@ namespace Aquality.Selenium.Tests.Integration
         [Test]
         public void Should_ExpandShadowRoot_FromElement()
         {
-            Assert.IsNotNull(form.ExpandShadowRoot(), "Should be possible to expand shadow root and get Selenium native ShadowRoot object");            
+            Assert.IsNotNull(form.ExpandShadowRoot(), "Should be possible to expand shadow root and get Selenium native ShadowRoot object");
+        }
+
+        [Test]
+        public void Should_BePossibleTo_FindElement_InShadowRoot()
+        {
             Assert.IsNotNull(form.DownloadsToolbarLabel.GetElement(), "Should be possible do get the element hidden under the shadow");
+            Assert.IsNotNull(form.DownloadsToolbarLabel.FindElementInShadowRoot<ILabel>(ChromeDownloadsForm.NestedShadowRootLocator, "More actions menu").GetElement(),
+                "Should be possible to expand the nested shadow root and get the element from it");            
+            Assert.IsTrue(form.MainContainerLabel.State.IsDisplayed, "Should be possible to check that element under the shadow is displayed");
+        }
+
+        [Test]
+        public void Should_BePossibleTo_FindElements_InShadowRoot()
+        {
             var elementLabels = form.DivElementLabels;
             Assert.That(elementLabels, Has.Count.GreaterThan(1), "Should be possible to find multiple elements hidden under the shadow");
             Assert.That(elementLabels.First().Locator.Mechanism, Contains.Substring("css"), "Unique locator of correct type should be generated");
             Assert.That(elementLabels.First().GetElement().TagName, Is.EqualTo("div"), "Should be possible to work with one of found elements");
-            Assert.IsNotNull(form.DownloadsToolbarLabel.FindElementInShadowRoot<ILabel>(ChromeDownloadsForm.NestedShadowRootLocator, "More actions menu").GetElement(),
-                "Should be possible to expand the nested shadow root and get the element from it");
-            
-            Assert.IsTrue(form.MainContainerLabel.State.IsDisplayed, "Should be possible to check that element under the shadow is displayed");
+            Assert.That(form.MainContainerLabels.First().GetElement().TagName, Is.EqualTo("div"), "Should be possible to work with one of found elements found by id");
         }
 
         [Test]
@@ -39,6 +49,7 @@ namespace Aquality.Selenium.Tests.Integration
             Assert.That(elementLabels, Has.Count.GreaterThan(1), "Should be possible to find multiple elements hidden under the shadow");
             Assert.That(elementLabels.First().Locator.Mechanism, Contains.Substring("css"), "Unique locator of correct type should be generated");
             Assert.That(elementLabels.First().GetElement().TagName, Is.EqualTo("div"), "Should be possible to work with one of found elements");
+            Assert.That(form.MainContainerLabelsFromJs.First().GetElement().TagName, Is.EqualTo("div"), "Should be possible to work with one of found elements found by id");
             Assert.IsNotNull(form.DownloadsToolbarLabelFromJs.JsActions.FindElementInShadowRoot<ILabel>(ChromeDownloadsForm.NestedShadowRootLocator, "More actions menu").GetElement(),
                 "Should be possible to expand the nested shadow root and get the element from it");
             Assert.IsTrue(form.MainContainerLabelFromJs.State.IsDisplayed, "Should be possible to check that element under the shadow is displayed");

--- a/Aquality.Selenium/tests/Aquality.Selenium.Tests/Integration/TestApp/Browser/ChromeDownloadsForm.cs
+++ b/Aquality.Selenium/tests/Aquality.Selenium.Tests/Integration/TestApp/Browser/ChromeDownloadsForm.cs
@@ -13,9 +13,11 @@ namespace Aquality.Selenium.Tests.Integration.TestApp.Browser.Forms
         public static By NestedShadowRootLocator => By.Id("moreActionsMenu");
         public ILabel DownloadsToolbarLabel => FormElement.FindElementInShadowRoot<ILabel>(By.CssSelector("downloads-toolbar"), "Downloads toolbar");
         public IList<ILabel> DivElementLabels => FormElement.FindElementsInShadowRoot<ILabel>(By.CssSelector("div"), "div");
+        public IList<ILabel> MainContainerLabels => FormElement.FindElementsInShadowRoot<ILabel>(By.Id("mainContainer"), "main container");
         public ILabel MainContainerLabel => FormElement.FindElementInShadowRoot<ILabel>(By.Id("mainContainer"), "main container");
         public ILabel DownloadsToolbarLabelFromJs => FormElement.JsActions.FindElementInShadowRoot<ILabel>(By.CssSelector("downloads-toolbar"), "Downloads toolbar");
         public IList<ILabel> DivElementLabelsFromJs => FormElement.JsActions.FindElementsInShadowRoot<ILabel>(By.CssSelector("div"), "div");
+        public IList<ILabel> MainContainerLabelsFromJs => FormElement.JsActions.FindElementsInShadowRoot<ILabel>(By.Id("mainContainer"), "main container");
         public ILabel MainContainerLabelFromJs => FormElement.JsActions.FindElementInShadowRoot<ILabel>(By.Id("mainContainer"), "Main container");
 
         public ChromeDownloadsForm() : base(By.TagName("downloads-manager"), "Chrome downloads manager")

--- a/Aquality.Selenium/tests/Aquality.Selenium.Tests/Integration/TestApp/Browser/ChromeDownloadsForm.cs
+++ b/Aquality.Selenium/tests/Aquality.Selenium.Tests/Integration/TestApp/Browser/ChromeDownloadsForm.cs
@@ -2,6 +2,7 @@
 using Aquality.Selenium.Elements.Interfaces;
 using Aquality.Selenium.Forms;
 using OpenQA.Selenium;
+using System.Collections.Generic;
 
 namespace Aquality.Selenium.Tests.Integration.TestApp.Browser.Forms
 {
@@ -11,8 +12,10 @@ namespace Aquality.Selenium.Tests.Integration.TestApp.Browser.Forms
 
         public static By NestedShadowRootLocator => By.Id("moreActionsMenu");
         public ILabel DownloadsToolbarLabel => FormElement.FindElementInShadowRoot<ILabel>(By.CssSelector("downloads-toolbar"), "Downloads toolbar");
+        public IList<ILabel> DivElementLabels => FormElement.FindElementsInShadowRoot<ILabel>(By.CssSelector("div"), "div");
         public ILabel MainContainerLabel => FormElement.FindElementInShadowRoot<ILabel>(By.Id("mainContainer"), "main container");
         public ILabel DownloadsToolbarLabelFromJs => FormElement.JsActions.FindElementInShadowRoot<ILabel>(By.CssSelector("downloads-toolbar"), "Downloads toolbar");
+        public IList<ILabel> DivElementLabelsFromJs => FormElement.JsActions.FindElementsInShadowRoot<ILabel>(By.CssSelector("div"), "div");
         public ILabel MainContainerLabelFromJs => FormElement.JsActions.FindElementInShadowRoot<ILabel>(By.Id("mainContainer"), "Main container");
 
         public ChromeDownloadsForm() : base(By.TagName("downloads-manager"), "Chrome downloads manager")


### PR DESCRIPTION
- add JavaScript to generate CSS selector from element
- try to generate CSS selector if XPath generation fails - necessary for ShadowRoot elements since XPath doesn't work for them

Closes #235 