### PR TITLE
Replace WebDriverManager usage with Selenium Manager +semver: feature

### DIFF
--- a/Aquality.Selenium/src/Aquality.Selenium/Aquality.Selenium.csproj
+++ b/Aquality.Selenium/src/Aquality.Selenium/Aquality.Selenium.csproj
@@ -14,7 +14,7 @@
     <RepositoryType>git</RepositoryType>
     <PackageTags>selenium webdriver browser automation</PackageTags>
     <PackageLicenseFile>LICENSE</PackageLicenseFile>
-    <Copyright>Copyright 2023 Aquality Automation</Copyright>
+    <Copyright>Copyright 2024 Aquality Automation</Copyright>
     <IsPackable>true</IsPackable>
   </PropertyGroup>
 
@@ -76,7 +76,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Aquality.Selenium.Core" Version="3.0.4" />
+    <PackageReference Include="Aquality.Selenium.Core" Version="3.0.5" />
     <PackageReference Include="WebDriverManager" Version="2.17.1" />
   </ItemGroup>
 

--- a/Aquality.Selenium/src/Aquality.Selenium/Aquality.Selenium.xml
+++ b/Aquality.Selenium/src/Aquality.Selenium/Aquality.Selenium.xml
@@ -1108,16 +1108,6 @@
             Describes web driver settings.
             </summary>
         </member>
-        <member name="P:Aquality.Selenium.Configurations.WebDriverSettings.IDriverSettings.WebDriverVersion">
-            <summary>
-            Gets version of web driver for WebDriverManager.
-            </summary>
-        </member>
-        <member name="P:Aquality.Selenium.Configurations.WebDriverSettings.IDriverSettings.SystemArchitecture">
-            <summary>
-            Gets target system architecture for WebDriverManager.
-            </summary>
-        </member>
         <member name="P:Aquality.Selenium.Configurations.WebDriverSettings.IDriverSettings.DriverOptions">
             <summary>
             Gets desired options for web driver.

--- a/Aquality.Selenium/src/Aquality.Selenium/Browsers/LocalBrowserFactory.cs
+++ b/Aquality.Selenium/src/Aquality.Selenium/Browsers/LocalBrowserFactory.cs
@@ -10,10 +10,11 @@ using OpenQA.Selenium.Safari;
 using System;
 using System.IO;
 using WebDriverManager;
-using WebDriverManager.DriverConfigs;
 using WebDriverManager.DriverConfigs.Impl;
-using WebDriverManager.Helpers;
 using Aquality.Selenium.Core.Localization;
+using System.Reflection;
+using System.Text.RegularExpressions;
+using Aquality.Selenium.Core.Logging;
 
 namespace Aquality.Selenium.Browsers
 {
@@ -22,8 +23,9 @@ namespace Aquality.Selenium.Browsers
     /// </summary>
     public class LocalBrowserFactory : BrowserFactory
     {
-        private static readonly object WebDriverDownloadingLock = new object();
         private const string HostAddressDefault = "::1";
+        private const string DriverVersionVariableName = "SE_DRIVER_VERSION";
+        private static readonly Regex CurrentBrowserVersionRegex = new Regex("Current browser version is ([\\d,\\.]+)");
 
         public LocalBrowserFactory(IActionRetrier actionRetrier, IBrowserProfile browserProfile, ITimeoutConfiguration timeoutConfiguration, ILocalizedLogger localizedLogger)
             : base(actionRetrier, browserProfile, timeoutConfiguration, localizedLogger)
@@ -42,34 +44,36 @@ namespace Aquality.Selenium.Browsers
                 {
                     case BrowserName.Chrome:
                     case BrowserName.Yandex:
-                        SetUpDriver(new ChromeConfig(), driverSettings);
-                        driver = GetDriver<ChromeDriver>(ChromeDriverService.CreateDefaultService(),
+                        driver = GetDriver<ChromeDriver>(() => ChromeDriverService.CreateDefaultService(),
                             (ChromeOptions)driverSettings.DriverOptions, commandTimeout);
                         break;
                     case BrowserName.Firefox:
-                        SetUpDriver(new FirefoxConfig(), driverSettings);
-                        var geckoService = FirefoxDriverService.CreateDefaultService();
-                        geckoService.Host = ((FirefoxSettings)driverSettings).IsGeckoServiceHostDefaultEnabled ? HostAddressDefault : geckoService.Host;
-                        driver = GetDriver<FirefoxDriver>(geckoService, (FirefoxOptions)driverSettings.DriverOptions, commandTimeout);
+                        Func<DriverService> geckoServiceProvider = () =>
+                        {
+                            var geckoService = FirefoxDriverService.CreateDefaultService();
+                            geckoService.Host = ((FirefoxSettings)driverSettings).IsGeckoServiceHostDefaultEnabled ? HostAddressDefault : geckoService.Host;
+                            return geckoService;
+                        };
+
+                        driver = GetDriver<FirefoxDriver>(geckoServiceProvider, (FirefoxOptions)driverSettings.DriverOptions, commandTimeout);
                         break;
                     case BrowserName.IExplorer:
-                        SetUpDriver(new InternetExplorerConfig(), driverSettings);
-                        driver = GetDriver<InternetExplorerDriver>(InternetExplorerDriverService.CreateDefaultService(),
+                        driver = GetDriver<InternetExplorerDriver>(() => InternetExplorerDriverService.CreateDefaultService(),
                             (InternetExplorerOptions)driverSettings.DriverOptions, commandTimeout);
                         break;
                     case BrowserName.Edge:
-                        SetUpDriver(new EdgeConfig(), driverSettings);
-                        driver = GetDriver<EdgeDriver>(EdgeDriverService.CreateDefaultService(),
+                        driver = GetDriver<EdgeDriver>(() => EdgeDriverService.CreateDefaultService(),
                             (EdgeOptions)driverSettings.DriverOptions, commandTimeout);
                         break;
                     case BrowserName.Opera:
                         var config = new OperaConfig();
-                        var driverPath = SetUpDriver(config, driverSettings);
-                        driver = GetDriver<ChromeDriver>(ChromeDriverService.CreateDefaultService(Path.GetDirectoryName(driverPath), config.GetBinaryName()),
+                        var operaSettings = (OperaSettings) driverSettings;
+                        var driverPath = new DriverManager().SetUpDriver(config, operaSettings.WebDriverVersion, operaSettings.SystemArchitecture);
+                        driver = GetDriver<ChromeDriver>(() => ChromeDriverService.CreateDefaultService(Path.GetDirectoryName(driverPath), config.GetBinaryName()),
                             (ChromeOptions)driverSettings.DriverOptions, commandTimeout);
                         break;
                     case BrowserName.Safari:
-                        driver = GetDriver<SafariDriver>(SafariDriverService.CreateDefaultService(),
+                        driver = GetDriver<SafariDriver>(() => SafariDriverService.CreateDefaultService(),
                             (SafariOptions)driverSettings.DriverOptions, commandTimeout);
                         break;
                     default:
@@ -79,26 +83,21 @@ namespace Aquality.Selenium.Browsers
             }
         }
 
-        private WebDriver GetDriver<T>(DriverService driverService, DriverOptions driverOptions, TimeSpan commandTimeout) where T : WebDriver
+        private WebDriver GetDriver<T>(Func<DriverService> driverServiceProvider, DriverOptions driverOptions, TimeSpan commandTimeout) where T : WebDriver
         {
-            return (T)Activator.CreateInstance(typeof(T), driverService, driverOptions, commandTimeout);
-        }
-
-        private static string SetUpDriver(IDriverConfig driverConfig, IDriverSettings driverSettings)
-        {
-            var architecture = driverSettings.SystemArchitecture.Equals(Architecture.Auto) ? ArchitectureHelper.GetArchitecture() : driverSettings.SystemArchitecture;
-            var version = driverSettings.WebDriverVersion.Equals(VersionResolveStrategy.Latest) ? driverConfig.GetLatestVersion() : driverSettings.WebDriverVersion;
-            version = version.Equals(VersionResolveStrategy.MatchingBrowser) ? driverConfig.GetMatchingBrowserVersion() : version;
-            var url = UrlHelper.BuildUrl(architecture.Equals(Architecture.X32) ? driverConfig.GetUrl32() : driverConfig.GetUrl64(), version);
-            var binaryPath = FileHelper.GetBinDestination(driverConfig.GetName(), version, architecture, driverConfig.GetBinaryName());
-            if (!File.Exists(binaryPath) || !Environment.GetEnvironmentVariable("PATH").Contains(binaryPath))
+            try
             {
-                lock (WebDriverDownloadingLock)
-                {
-                    return new DriverManager().SetUpDriver(url, binaryPath);
-                }
+                return (T)Activator.CreateInstance(typeof(T), driverServiceProvider.Invoke(), driverOptions, commandTimeout);
             }
-            return binaryPath;
+            catch (TargetInvocationException exception)
+            when (exception.InnerException != null && CurrentBrowserVersionRegex.IsMatch(exception.InnerException.Message))
+            {
+                Logger.Instance.Debug(exception.InnerException.Message, exception);
+                var currentVersion = CurrentBrowserVersionRegex.Match(exception.InnerException.Message).Groups[1].Value;
+                Environment.SetEnvironmentVariable(DriverVersionVariableName, currentVersion);
+                return (T)Activator.CreateInstance(typeof(T), driverServiceProvider.Invoke(), driverOptions, commandTimeout);
+            }
+
         }
     }
 }

--- a/Aquality.Selenium/src/Aquality.Selenium/Configurations/WebDriverSettings/DriverSettings.cs
+++ b/Aquality.Selenium/src/Aquality.Selenium/Configurations/WebDriverSettings/DriverSettings.cs
@@ -6,7 +6,6 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
-using WebDriverManager.Helpers;
 
 namespace Aquality.Selenium.Configurations.WebDriverSettings
 {
@@ -31,10 +30,6 @@ namespace Aquality.Selenium.Configurations.WebDriverSettings
         }
 
         protected ISettingsFile SettingsFile { get; }
-
-        public virtual string WebDriverVersion => SettingsFile.GetValueOrDefault($"{DriverSettingsPath}.webDriverVersion", "Latest");
-
-        public Architecture SystemArchitecture => SettingsFile.GetValueOrDefault($"{DriverSettingsPath}.systemArchitecture", Architecture.Auto).ToEnum<Architecture>();
 
         public abstract DriverOptions DriverOptions { get; }
 

--- a/Aquality.Selenium/src/Aquality.Selenium/Configurations/WebDriverSettings/IDriverSettings.cs
+++ b/Aquality.Selenium/src/Aquality.Selenium/Configurations/WebDriverSettings/IDriverSettings.cs
@@ -1,5 +1,4 @@
 ﻿using OpenQA.Selenium;
-using WebDriverManager.Helpers;
 
 namespace Aquality.Selenium.Configurations.WebDriverSettings
 {
@@ -8,16 +7,6 @@ namespace Aquality.Selenium.Configurations.WebDriverSettings
     /// </summary>
     public interface IDriverSettings
     {
-        /// <summary>
-        /// Gets version of web driver for WebDriverManager.
-        /// </summary>
-        string WebDriverVersion { get; }
-
-        /// <summary>
-        /// Gets target system architecture for WebDriverManager.
-        /// </summary>
-        Architecture SystemArchitecture { get; }
-
         /// <summary>
         /// Gets desired options for web driver.
         /// </summary>

--- a/Aquality.Selenium/src/Aquality.Selenium/Configurations/WebDriverSettings/OperaSettings.cs
+++ b/Aquality.Selenium/src/Aquality.Selenium/Configurations/WebDriverSettings/OperaSettings.cs
@@ -8,6 +8,7 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Reflection;
+using WebDriverManager.Helpers;
 
 namespace Aquality.Selenium.Configurations.WebDriverSettings
 {
@@ -17,6 +18,7 @@ namespace Aquality.Selenium.Configurations.WebDriverSettings
     public class OperaSettings : ChromeSettings
     {
         private const string DefaultBinaryLocation = "%USERPROFILE%\\AppData\\Local\\Programs\\Opera\\launcher.exe";
+
         /// <summary>
         /// Instantiates class using JSON file with general settings.
         /// </summary>
@@ -24,6 +26,10 @@ namespace Aquality.Selenium.Configurations.WebDriverSettings
         public OperaSettings(ISettingsFile settingsFile) : base(settingsFile)
         {
         }
+
+        public virtual string WebDriverVersion => SettingsFile.GetValueOrDefault($"{DriverSettingsPath}.webDriverVersion", "Latest");
+
+        public Architecture SystemArchitecture => SettingsFile.GetValueOrDefault($"{DriverSettingsPath}.systemArchitecture", Architecture.Auto).ToEnum<Architecture>();
 
         public virtual string BinaryLocation
         {

--- a/Aquality.Selenium/src/Aquality.Selenium/Resources/settings.json
+++ b/Aquality.Selenium/src/Aquality.Selenium/Resources/settings.json
@@ -6,7 +6,6 @@
 
   "driverSettings": {
     "chrome": {
-      "webDriverVersion": "MatchingBrowser",
       "capabilities": {
         "selenoid:options": 
         { 
@@ -30,7 +29,6 @@
       "pageLoadStrategy": "Normal"
     },
     "firefox": {
-      "webDriverVersion": "Latest",
       "isGeckoServiceHostDefaultEnabled": false,
       "capabilities": {
         "enableVNC": true,
@@ -54,8 +52,6 @@
       "startArguments": []
     },
     "iexplorer": {
-      "webDriverVersion": "Latest",
-      "systemArchitecture": "X32",
       "capabilities": {
         "ignoreProtectedModeSettings": true,
         "unhandledPromptBehavior": "default"
@@ -104,7 +100,6 @@
       "startArguments": ["--remote-debugging-port=9222", "--no-sandbox", "--disable-dev-shm-usage"]
     },
     "yandex": {
-      "webDriverVersion": "102.0.5005.61",
       "binaryLocation": "%USERPROFILE%\\AppData\\Local\\Yandex\\YandexBrowser\\Application\\browser.exe",
       "capabilities": {
         "enableVNC": true,

--- a/Aquality.Selenium/tests/Aquality.Selenium.Tests/Integration/DevToolsEmulationTests.cs
+++ b/Aquality.Selenium/tests/Aquality.Selenium.Tests/Integration/DevToolsEmulationTests.cs
@@ -58,11 +58,11 @@ namespace Aquality.Selenium.Tests.Integration
         {
             void setAction(long width, long height, bool isMobile, double scaleFactor)
             {
-                var parameters = new OpenQA.Selenium.DevTools.V119.Emulation.SetDeviceMetricsOverrideCommandSettings
+                var parameters = new OpenQA.Selenium.DevTools.V120.Emulation.SetDeviceMetricsOverrideCommandSettings
                 {
-                    DisplayFeature = new OpenQA.Selenium.DevTools.V119.Emulation.DisplayFeature
+                    DisplayFeature = new OpenQA.Selenium.DevTools.V120.Emulation.DisplayFeature
                     {
-                        Orientation = OpenQA.Selenium.DevTools.V119.Emulation.DisplayFeatureOrientationValues.Horizontal
+                        Orientation = OpenQA.Selenium.DevTools.V120.Emulation.DisplayFeatureOrientationValues.Horizontal
                     },
                     Width = width,
                     Height = height,

--- a/Aquality.Selenium/tests/Aquality.Selenium.Tests/Integration/Usecases/CustomBrowserFactoryTests.cs
+++ b/Aquality.Selenium/tests/Aquality.Selenium.Tests/Integration/Usecases/CustomBrowserFactoryTests.cs
@@ -66,9 +66,8 @@ namespace Aquality.Selenium.Tests.Integration.Usecases
             
             private static void SetUpDriver(IDriverConfig driverConfig, IDriverSettings driverSettings)
             {
-                var architecture = driverSettings.SystemArchitecture.Equals(Architecture.Auto) ? ArchitectureHelper.GetArchitecture() : driverSettings.SystemArchitecture;
-                var version = driverSettings.WebDriverVersion.Equals("Latest") ? driverConfig.GetLatestVersion() : driverSettings.WebDriverVersion;
-                version = version.Equals(VersionResolveStrategy.MatchingBrowser) ? driverConfig.GetMatchingBrowserVersion() : version;
+                var architecture = ArchitectureHelper.GetArchitecture();
+                var version = driverConfig.GetMatchingBrowserVersion();
                 var url = UrlHelper.BuildUrl(architecture.Equals(Architecture.X32) ? driverConfig.GetUrl32() : driverConfig.GetUrl64(), version);
                 var binaryPath = FileHelper.GetBinDestination(driverConfig.GetName(), version, architecture, driverConfig.GetBinaryName());
                 if (!File.Exists(binaryPath) || !Environment.GetEnvironmentVariable("PATH").Contains(binaryPath))

--- a/Aquality.Selenium/tests/Aquality.Selenium.Tests/Resources/settings.azure.json
+++ b/Aquality.Selenium/tests/Aquality.Selenium.Tests/Resources/settings.azure.json
@@ -6,7 +6,6 @@
 
   "driverSettings": {
     "chrome": {
-      "webDriverVersion": "MatchingBrowser",
       "capabilities": {
         "selenoid:options": 
         { 
@@ -30,8 +29,6 @@
       "pageLoadStrategy": "Normal"
     },
     "firefox": {
-      "webDriverVersion": "0.24.0",
-      "systemArchitecture": "X64",
       "capabilities": {
         "enableVNC": true
       },
@@ -53,8 +50,6 @@
       "startArguments": []
     },
     "iexplorer": {
-      "webDriverVersion": "Latest",
-      "systemArchitecture": "X32",
       "capabilities": {
         "ignoreProtectedModeSettings": true
       },
@@ -62,7 +57,6 @@
       "startArguments": []
     },
     "edge": {
-      "webDriverVersion": "Latest",
       "capabilities": {
         "enableVNC": true
       },

--- a/Aquality.Selenium/tests/Aquality.Selenium.Tests/Resources/settings.json
+++ b/Aquality.Selenium/tests/Aquality.Selenium.Tests/Resources/settings.json
@@ -6,7 +6,6 @@
 
   "driverSettings": {
     "chrome": {
-      "webDriverVersion": "MatchingBrowser",
       "capabilities": {
         "selenoid:options": 
         { 
@@ -30,8 +29,6 @@
       "pageLoadStrategy": "Normal"
     },
     "firefox": {
-      "webDriverVersion": "Latest",
-      "systemArchitecture": "X64",
       "capabilities": {
         "enableVNC": true,
         "unhandledPromptBehavior": "ignore"
@@ -54,8 +51,6 @@
       "startArguments": []
     },
     "iexplorer": {
-      "webDriverVersion": "Latest",
-      "systemArchitecture": "X32",
       "capabilities": {
         "ignoreProtectedModeSettings": true,
         "requireWindowFocus": false,
@@ -64,7 +59,6 @@
       }
     },
     "edge": {
-      "webDriverVersion": "Latest",
       "capabilities": {
         "enableVNC": true,
         "unhandledPromptBehavior": "ignore"
@@ -103,7 +97,6 @@
       "startArguments": ["--remote-debugging-port=9222", "--no-sandbox", "--disable-dev-shm-usage"]
     },
     "yandex": {
-      "webDriverVersion": "102.0.5005.61",
       "binaryLocation": "%USERPROFILE%\\AppData\\Local\\Yandex\\YandexBrowser\\Application\\browser.exe",
       "capabilities": {
         "enableVNC": true,

--- a/Aquality.Selenium/tests/Aquality.Selenium.Tests/Resources/settings.local.json
+++ b/Aquality.Selenium/tests/Aquality.Selenium.Tests/Resources/settings.local.json
@@ -6,7 +6,6 @@
 
   "driverSettings": {
     "chrome": {
-      "webDriverVersion": "80.0.3987.106",
       "capabilities": {
         "enableVNC": true
       },
@@ -28,7 +27,6 @@
       ]
     },
     "firefox": {
-      "webDriverVersion": "Latest",
       "capabilities": {
         "enableVNC": true
       },
@@ -50,8 +48,6 @@
       "startArguments": []
     },
     "iexplorer": {
-      "webDriverVersion": "Latest",
-      "systemArchitecture": "X32",
       "capabilities": {
         "ignoreProtectedModeSettings": true
       },
@@ -59,7 +55,6 @@
       "startArguments": []
     },
     "edge": {
-      "webDriverVersion": "Latest",
       "capabilities": {
         "enableVNC": true
       },

--- a/LICENSE
+++ b/LICENSE
@@ -186,7 +186,7 @@
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright 2023 Aquality Automation
+   Copyright 2024 Aquality Automation
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.


### PR DESCRIPTION
- Use build-in Selenium manager in most cases, except of the Opera browser

- Retry driver creation if exception contains the driver version, with setting it to Selenium manager

- Remove webDriverVersion and systemArchitecture from settings

- Update Aquality.Selenium.Core to v.3.0.5, so that Selenium is updated to v.4.16.2

- Update year for license and package

closes #229