### PR TITLE
[Feature] DevTools command logging options

### DIFF
--- a/Aquality.Selenium/src/Aquality.Selenium/Aquality.Selenium.xml
+++ b/Aquality.Selenium/src/Aquality.Selenium/Aquality.Selenium.xml
@@ -571,16 +571,17 @@
             Defaults to autodetect the protocol version for <see cref="T:OpenQA.Selenium.Chromium.ChromiumDriver"/>, V85 for FirefoxDriver.</param>
             <returns>The active session to use to communicate with the Chromium Developer Tools debugging protocol.</returns>
         </member>
-        <member name="M:Aquality.Selenium.Browsers.DevToolsHandling.ExecuteCdpCommand(System.String,System.Collections.Generic.Dictionary{System.String,System.Object})">
+        <member name="M:Aquality.Selenium.Browsers.DevToolsHandling.ExecuteCdpCommand(System.String,System.Collections.Generic.Dictionary{System.String,System.Object},Aquality.Selenium.Logging.DevToolsCommandLoggingOptions)">
             <summary>
             Executes a custom Chromium Dev Tools Protocol Command.
             Note: works only if current driver is instance of <see cref="T:OpenQA.Selenium.Chromium.ChromiumDriver"/>.
             </summary>
             <param name="commandName">Name of the command to execute.</param>
             <param name="commandParameters">Parameters of the command to execute.</param>
+            <param name="loggingOptions">Logging preferences.</param>
             <returns>An object representing the result of the command, if applicable.</returns>
         </member>
-        <member name="M:Aquality.Selenium.Browsers.DevToolsHandling.SendCommand(System.String,Newtonsoft.Json.Linq.JToken,System.Threading.CancellationToken,System.Nullable{System.Int32},System.Boolean)">
+        <member name="M:Aquality.Selenium.Browsers.DevToolsHandling.SendCommand(System.String,Newtonsoft.Json.Linq.JToken,System.Threading.CancellationToken,System.Nullable{System.Int32},System.Boolean,Aquality.Selenium.Logging.DevToolsCommandLoggingOptions)">
             <summary>
             Sends the specified command and returns the associated command response.
             </summary>
@@ -589,6 +590,7 @@
             <param name="cancellationToken">A CancellationToken object to allow for cancellation of the command.</param>
             <param name="millisecondsTimeout">The execution timeout of the command in milliseconds.</param>
             <param name="throwExceptionIfResponseNotReceived"><see langword="true"/> to throw an exception if a response is not received; otherwise, <see langword="false"/>.</param>
+            <param name="loggingOptions">Logging preferences.</param>
             <returns>A JToken based on a command created with the specified command name and parameters.</returns>
         </member>
         <member name="M:Aquality.Selenium.Browsers.DevToolsHandling.SendCommand(OpenQA.Selenium.DevTools.ICommand,System.Threading.CancellationToken,System.Nullable{System.Int32},System.Boolean)">
@@ -2202,6 +2204,21 @@
             </summary>
             <param name="x">horizontal coordinate</param>
             <param name="y">vertical coordinate</param>
+        </member>
+        <member name="T:Aquality.Selenium.Logging.DevToolsCommandLoggingOptions">
+            <summary>
+            DevTools Command/Result logging options.
+            </summary>
+        </member>
+        <member name="P:Aquality.Selenium.Logging.DevToolsCommandLoggingOptions.Command">
+            <summary>
+            Controls logging of command info: name and parameters (if any).
+            </summary>
+        </member>
+        <member name="P:Aquality.Selenium.Logging.DevToolsCommandLoggingOptions.Result">
+            <summary>
+            Controls logging of command result (if present).
+            </summary>
         </member>
         <member name="T:Aquality.Selenium.Logging.HttpExchangeLoggingOptions">
             <summary>

--- a/Aquality.Selenium/src/Aquality.Selenium/Browsers/BrowserNavigation.cs
+++ b/Aquality.Selenium/src/Aquality.Selenium/Browsers/BrowserNavigation.cs
@@ -52,6 +52,11 @@ namespace Aquality.Selenium.Browsers
             catch (WebDriverException e) when (driver.Url == url)
             {
                 Logger.Fatal($"Navigation error occurred: [{e.Message}], but successfully navigated to URL [{url}]", e);
+                // ignore only unknown errors
+                if (e.GetType() != typeof(WebDriverException))
+                {
+                    throw;
+                }
             }            
         }
 

--- a/Aquality.Selenium/src/Aquality.Selenium/Browsers/DevToolsHandling.cs
+++ b/Aquality.Selenium/src/Aquality.Selenium/Browsers/DevToolsHandling.cs
@@ -1,4 +1,5 @@
 ﻿using Aquality.Selenium.Core.Localization;
+using Aquality.Selenium.Logging;
 using Newtonsoft.Json.Linq;
 using OpenQA.Selenium;
 using OpenQA.Selenium.Chromium;
@@ -92,15 +93,16 @@ namespace Aquality.Selenium.Browsers
         /// </summary>
         /// <param name="commandName">Name of the command to execute.</param>
         /// <param name="commandParameters">Parameters of the command to execute.</param>
+        /// <param name="loggingOptions">Logging preferences.</param>
         /// <returns>An object representing the result of the command, if applicable.</returns>
-        public object ExecuteCdpCommand(string commandName, Dictionary<string, object> commandParameters)
+        public object ExecuteCdpCommand(string commandName, Dictionary<string, object> commandParameters, DevToolsCommandLoggingOptions loggingOptions = null)
         {
             if (devToolsProvider is ChromiumDriver driver)
             {
-                LogCommand(commandName, JToken.FromObject(commandParameters));
+                LogCommand(commandName, JToken.FromObject(commandParameters), loggingOptions);
                 var result = driver.ExecuteCdpCommand(commandName, commandParameters);
                 var formattedResult = JToken.FromObject(result);
-                LogCommandResult(formattedResult);
+                LogCommandResult(formattedResult, loggingOptions);
                 return result;
             }
             else
@@ -117,15 +119,17 @@ namespace Aquality.Selenium.Browsers
         /// <param name="cancellationToken">A CancellationToken object to allow for cancellation of the command.</param>
         /// <param name="millisecondsTimeout">The execution timeout of the command in milliseconds.</param>
         /// <param name="throwExceptionIfResponseNotReceived"><see langword="true"/> to throw an exception if a response is not received; otherwise, <see langword="false"/>.</param>
+        /// <param name="loggingOptions">Logging preferences.</param>
         /// <returns>A JToken based on a command created with the specified command name and parameters.</returns>
         public async Task<JToken> SendCommand(string commandName, JToken commandParameters = null, 
-            CancellationToken cancellationToken = default, int? millisecondsTimeout = null, bool throwExceptionIfResponseNotReceived = true)
+            CancellationToken cancellationToken = default, int? millisecondsTimeout = null, bool throwExceptionIfResponseNotReceived = true, 
+            DevToolsCommandLoggingOptions loggingOptions = null)
         {
             var parameters = commandParameters ?? new JObject();
-            LogCommand(commandName, parameters);
+            LogCommand(commandName, parameters, loggingOptions);
             var result = await devToolsProvider.GetDevToolsSession()
                 .SendCommand(commandName, parameters, cancellationToken, millisecondsTimeout, throwExceptionIfResponseNotReceived);
-            LogCommandResult(result);            
+            LogCommandResult(result, loggingOptions);            
             return result;
         }
 
@@ -144,21 +148,33 @@ namespace Aquality.Selenium.Browsers
                 cancellationToken, millisecondsTimeout, throwExceptionIfResponseNotReceived);
         }
 
-        private void LogCommand(string commandName, JToken commandParameters)
+        private void LogCommand(string commandName, JToken commandParameters, DevToolsCommandLoggingOptions loggingOptions = null)
         {
+            if (loggingOptions == null)
+            {
+                loggingOptions = new DevToolsCommandLoggingOptions();
+            }
+            if (!loggingOptions.Result.Enabled)
+            {
+                return;
+            }
             if (commandParameters.Any())
             {
-                Logger.Info("loc.browser.devtools.command.execute.withparams", commandName, commandParameters.ToString());
+                Logger.LogByLevel(loggingOptions.Command.LogLevel, "loc.browser.devtools.command.execute.withparams", commandName, commandParameters.ToString());
             }
             else
             {
-                Logger.Info("loc.browser.devtools.command.execute", commandName);
+                Logger.LogByLevel(loggingOptions.Command.LogLevel, "loc.browser.devtools.command.execute", commandName);
             }
         }
 
-        private void LogCommandResult(JToken result)
+        private void LogCommandResult(JToken result, DevToolsCommandLoggingOptions loggingOptions = null)
         {
-            if (result.Any())
+            if (loggingOptions == null)
+            {
+                loggingOptions = new DevToolsCommandLoggingOptions();
+            }
+            if (result.Any() && loggingOptions.Result.Enabled)
             {
                 Logger.Info("loc.browser.devtools.command.execute.result", result.ToString());
             }

--- a/Aquality.Selenium/src/Aquality.Selenium/Logging/DevToolsCommandLoggingOptions.cs
+++ b/Aquality.Selenium/src/Aquality.Selenium/Logging/DevToolsCommandLoggingOptions.cs
@@ -1,0 +1,18 @@
+﻿namespace Aquality.Selenium.Logging
+{
+    /// <summary>
+    /// DevTools Command/Result logging options.
+    /// </summary>
+    public class DevToolsCommandLoggingOptions
+    {
+        /// <summary>
+        /// Controls logging of command info: name and parameters (if any).
+        /// </summary>
+        public LoggingParameters Command { get; set; } = new LoggingParameters { Enabled = true, LogLevel = LogLevel.Info };
+
+        /// <summary>
+        /// Controls logging of command result (if present).
+        /// </summary>
+        public LoggingParameters Result { get; set; } = new LoggingParameters { Enabled = true, LogLevel = LogLevel.Info };        
+    }
+}

--- a/Aquality.Selenium/tests/Aquality.Selenium.Tests/Integration/DevToolsEmulationTests.cs
+++ b/Aquality.Selenium/tests/Aquality.Selenium.Tests/Integration/DevToolsEmulationTests.cs
@@ -1,4 +1,5 @@
 ﻿using Aquality.Selenium.Browsers;
+using Aquality.Selenium.Logging;
 using Aquality.Selenium.Tests.Integration.TestApp.ManyTools.Forms;
 using Aquality.Selenium.Tests.Integration.TestApp.MyLocation;
 using Aquality.Selenium.Tests.Integration.TestApp.TheInternet.Forms;
@@ -113,7 +114,8 @@ namespace Aquality.Selenium.Tests.Integration
                         { "latitude", latitude},
                         { "longitude", longitude},
                         { "accuracy", accuracy},
-                       }),
+                       },
+                       new DevToolsCommandLoggingOptions { Command = new LoggingParameters { Enabled = false } , Result = new LoggingParameters { Enabled = false } }),
                    () => DevTools.ExecuteCdpCommand(new ClearGeolocationOverrideCommandSettings().CommandName, new Dictionary<string, object>()));
         }
 


### PR DESCRIPTION
Add optional parameter for DevTools Command/Result logging options to SendComand and ExecuteCdpCommand methods closes #246