### PR TITLE
Enhance DevTools command logging options

### DIFF
--- a/Aquality.Selenium/src/Aquality.Selenium/Aquality.Selenium.xml
+++ b/Aquality.Selenium/src/Aquality.Selenium/Aquality.Selenium.xml
@@ -593,7 +593,7 @@
             <param name="loggingOptions">Logging preferences.</param>
             <returns>A JToken based on a command created with the specified command name and parameters.</returns>
         </member>
-        <member name="M:Aquality.Selenium.Browsers.DevToolsHandling.SendCommand(OpenQA.Selenium.DevTools.ICommand,System.Threading.CancellationToken,System.Nullable{System.Int32},System.Boolean)">
+        <member name="M:Aquality.Selenium.Browsers.DevToolsHandling.SendCommand(OpenQA.Selenium.DevTools.ICommand,System.Threading.CancellationToken,System.Nullable{System.Int32},System.Boolean,Aquality.Selenium.Logging.DevToolsCommandLoggingOptions)">
             <summary>
             Sends the specified command and returns the associated command response.
             </summary>
@@ -601,6 +601,7 @@
             <param name="cancellationToken">A CancellationToken object to allow for cancellation of the command.</param>
             <param name="millisecondsTimeout">The execution timeout of the command in milliseconds.</param>
             <param name="throwExceptionIfResponseNotReceived"><see langword="true"/> to throw an exception if a response is not received; otherwise, <see langword="false"/>.</param>
+            <param name="loggingOptions">Logging preferences.</param>
             <returns>A JToken based on a command created with the specified command name and parameters.</returns>
         </member>
         <member name="T:Aquality.Selenium.Browsers.DevToolsPerformanceExtensions">

--- a/Aquality.Selenium/src/Aquality.Selenium/Browsers/DevToolsHandling.cs
+++ b/Aquality.Selenium/src/Aquality.Selenium/Browsers/DevToolsHandling.cs
@@ -140,43 +140,39 @@ namespace Aquality.Selenium.Browsers
         /// <param name="cancellationToken">A CancellationToken object to allow for cancellation of the command.</param>
         /// <param name="millisecondsTimeout">The execution timeout of the command in milliseconds.</param>
         /// <param name="throwExceptionIfResponseNotReceived"><see langword="true"/> to throw an exception if a response is not received; otherwise, <see langword="false"/>.</param>
+        /// <param name="loggingOptions">Logging preferences.</param>
         /// <returns>A JToken based on a command created with the specified command name and parameters.</returns>
         public async Task<JToken> SendCommand(ICommand commandWithParameters,
-            CancellationToken cancellationToken = default, int? millisecondsTimeout = null, bool throwExceptionIfResponseNotReceived = true)
+            CancellationToken cancellationToken = default, int? millisecondsTimeout = null, bool throwExceptionIfResponseNotReceived = true, 
+            DevToolsCommandLoggingOptions loggingOptions = null)
         {
             return await SendCommand(commandWithParameters.CommandName, JToken.FromObject(commandWithParameters), 
-                cancellationToken, millisecondsTimeout, throwExceptionIfResponseNotReceived);
+                cancellationToken, millisecondsTimeout, throwExceptionIfResponseNotReceived, loggingOptions);
         }
 
         private void LogCommand(string commandName, JToken commandParameters, DevToolsCommandLoggingOptions loggingOptions = null)
         {
-            if (loggingOptions == null)
-            {
-                loggingOptions = new DevToolsCommandLoggingOptions();
-            }
-            if (!loggingOptions.Result.Enabled)
+            var logging = (loggingOptions ?? new DevToolsCommandLoggingOptions()).Command;
+            if (!logging.Enabled)
             {
                 return;
             }
             if (commandParameters.Any())
             {
-                Logger.LogByLevel(loggingOptions.Command.LogLevel, "loc.browser.devtools.command.execute.withparams", commandName, commandParameters.ToString());
+                Logger.LogByLevel(logging.LogLevel, "loc.browser.devtools.command.execute.withparams", commandName, commandParameters.ToString());
             }
             else
             {
-                Logger.LogByLevel(loggingOptions.Command.LogLevel, "loc.browser.devtools.command.execute", commandName);
+                Logger.LogByLevel(logging.LogLevel, "loc.browser.devtools.command.execute", commandName);
             }
         }
 
         private void LogCommandResult(JToken result, DevToolsCommandLoggingOptions loggingOptions = null)
         {
-            if (loggingOptions == null)
+            var logging = (loggingOptions ?? new DevToolsCommandLoggingOptions()).Result;
+            if (result.Any() && logging.Enabled)
             {
-                loggingOptions = new DevToolsCommandLoggingOptions();
-            }
-            if (result.Any() && loggingOptions.Result.Enabled)
-            {
-                Logger.Info("loc.browser.devtools.command.execute.result", result.ToString());
+                Logger.LogByLevel(logging.LogLevel, "loc.browser.devtools.command.execute.result", result.ToString());
             }
         }
     }


### PR DESCRIPTION
Add optional parameter for DevTools Command/Result logging options to SendComand and ExecuteCdpCommand methods closes #246
fixes #247