### PR TITLE
Update to use Selenium 4.24.0 +semver:feature

### DIFF
--- a/Aquality.Selenium/src/Aquality.Selenium/Aquality.Selenium.csproj
+++ b/Aquality.Selenium/src/Aquality.Selenium/Aquality.Selenium.csproj
@@ -86,7 +86,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Aquality.Selenium.Core" Version="3.0.12" />
+    <PackageReference Include="Aquality.Selenium.Core" Version="3.1.1" />
     <PackageReference Include="OpenCvSharp4.runtime.osx_arm64" Version="4.8.1-rc" />
     <PackageReference Include="WebDriverManager" Version="2.17.4" />
 	<PackageReference Include="OpenCvSharp4" Version="4.10.0.20240616" />

--- a/Aquality.Selenium/src/Aquality.Selenium/Aquality.Selenium.xml
+++ b/Aquality.Selenium/src/Aquality.Selenium/Aquality.Selenium.xml
@@ -671,14 +671,14 @@
             For more information, see <see href="https://chromedevtools.github.io/devtools-protocol/tot/Performance/"/>.
             </summary>
         </member>
-        <member name="M:Aquality.Selenium.Browsers.DevToolsPerformanceExtensions.DisablePerfomanceMonitoring(Aquality.Selenium.Browsers.DevToolsHandling)">
+        <member name="M:Aquality.Selenium.Browsers.DevToolsPerformanceExtensions.DisablePerformanceMonitoring(Aquality.Selenium.Browsers.DevToolsHandling)">
             <summary>
             Disable collecting and reporting metrics.
             </summary>
             <param name="devTools">Current instance of <see cref="T:Aquality.Selenium.Browsers.DevToolsHandling"/>.</param>
             <returns>A task for asynchronous command.</returns>
         </member>
-        <member name="M:Aquality.Selenium.Browsers.DevToolsPerformanceExtensions.EnablePerfomanceMonitoring(Aquality.Selenium.Browsers.DevToolsHandling,System.String)">
+        <member name="M:Aquality.Selenium.Browsers.DevToolsPerformanceExtensions.EnablePerformanceMonitoring(Aquality.Selenium.Browsers.DevToolsHandling,System.String)">
             <summary>
             Enable collecting and reporting metrics.
             </summary>

--- a/Aquality.Selenium/src/Aquality.Selenium/Aquality.Selenium.xml
+++ b/Aquality.Selenium/src/Aquality.Selenium/Aquality.Selenium.xml
@@ -349,6 +349,12 @@
             Navigates back.
             </summary>
         </member>
+        <member name="M:Aquality.Selenium.Browsers.BrowserNavigation.BackAsync">
+            <summary>
+            Move back a single entry in the browser's history as an asynchronous task.
+            </summary>
+            <returns>A task object representing the asynchronous operation.</returns>
+        </member>
         <member name="M:Aquality.Selenium.Browsers.BrowserNavigation.Forward">
             <summary>
             Navigates forward.
@@ -376,7 +382,7 @@
             <summary>
             Navigate to a url as an asynchronous task.
             </summary>
-            <param name="url">Uri object of where you want the browser to go.</param>
+            <param name="url">String representation of where you want the browser to go.</param>
             <returns>A task object representing the asynchronous operation.</returns>
         </member>
         <member name="M:Aquality.Selenium.Browsers.BrowserNavigation.GoToUrlAsync(System.Uri)">
@@ -636,17 +642,17 @@
             <param name="loggingOptions">Logging preferences.</param>
             <returns>An object representing the result of the command, if applicable.</returns>
         </member>
-        <member name="M:Aquality.Selenium.Browsers.DevToolsHandling.SendCommand(System.String,Newtonsoft.Json.Linq.JToken,System.Threading.CancellationToken,System.Nullable{System.Int32},System.Boolean,Aquality.Selenium.Logging.DevToolsCommandLoggingOptions)">
+        <member name="M:Aquality.Selenium.Browsers.DevToolsHandling.SendCommand(System.String,System.Text.Json.Nodes.JsonNode,System.Threading.CancellationToken,System.Nullable{System.Int32},System.Boolean,Aquality.Selenium.Logging.DevToolsCommandLoggingOptions)">
             <summary>
             Sends the specified command and returns the associated command response.
             </summary>
             <param name="commandName">The name of the command to send.</param>
-            <param name="commandParameters">The parameters of the command as a JToken object.</param>
+            <param name="commandParameters">The parameters of the command as a JsonNode object.</param>
             <param name="cancellationToken">A CancellationToken object to allow for cancellation of the command.</param>
             <param name="millisecondsTimeout">The execution timeout of the command in milliseconds.</param>
             <param name="throwExceptionIfResponseNotReceived"><see langword="true"/> to throw an exception if a response is not received; otherwise, <see langword="false"/>.</param>
             <param name="loggingOptions">Logging preferences.</param>
-            <returns>A JToken based on a command created with the specified command name and parameters.</returns>
+            <returns>A JsonNode based on a command created with the specified command name and parameters.</returns>
         </member>
         <member name="M:Aquality.Selenium.Browsers.DevToolsHandling.SendCommand(OpenQA.Selenium.DevTools.ICommand,System.Threading.CancellationToken,System.Nullable{System.Int32},System.Boolean,Aquality.Selenium.Logging.DevToolsCommandLoggingOptions)">
             <summary>
@@ -657,7 +663,7 @@
             <param name="millisecondsTimeout">The execution timeout of the command in milliseconds.</param>
             <param name="throwExceptionIfResponseNotReceived"><see langword="true"/> to throw an exception if a response is not received; otherwise, <see langword="false"/>.</param>
             <param name="loggingOptions">Logging preferences.</param>
-            <returns>A JToken based on a command created with the specified command name and parameters.</returns>
+            <returns>A JsonNode based on a command created with the specified command name and parameters.</returns>
         </member>
         <member name="T:Aquality.Selenium.Browsers.DevToolsPerformanceExtensions">
             <summary>
@@ -2360,6 +2366,11 @@
             Gets text value of an element.
             </summary>
             <value>String representation of element's value</value>
+        </member>
+        <member name="M:Aquality.Selenium.Elements.Interfaces.ITextBox.Clear">
+            <summary>
+            Clear element text.
+            </summary>
         </member>
         <member name="M:Aquality.Selenium.Elements.Interfaces.ITextBox.Type(System.String,System.Boolean)">
             <summary>

--- a/Aquality.Selenium/src/Aquality.Selenium/Browsers/DevToolsHandling.cs
+++ b/Aquality.Selenium/src/Aquality.Selenium/Browsers/DevToolsHandling.cs
@@ -32,7 +32,7 @@ namespace Aquality.Selenium.Browsers
             wasDevToolsSessionClosed = false;
         }
 
-        private ILocalizedLogger Logger => AqualityServices.LocalizedLogger;
+        private static ILocalizedLogger Logger => AqualityServices.LocalizedLogger;
 
         /// <summary>
         /// Gets a value indicating whether a DevTools session is active.
@@ -192,7 +192,7 @@ namespace Aquality.Selenium.Browsers
             }
         }
 
-        private bool IsNotEmpty(JsonNode jsonNode)
+        private static bool IsNotEmpty(JsonNode jsonNode)
         {
             return jsonNode is JsonArray array ? array.Any() : (jsonNode as JsonObject).Any();
         }

--- a/Aquality.Selenium/src/Aquality.Selenium/Browsers/DevToolsHandling.cs
+++ b/Aquality.Selenium/src/Aquality.Selenium/Browsers/DevToolsHandling.cs
@@ -166,7 +166,7 @@ namespace Aquality.Selenium.Browsers
                 cancellationToken, millisecondsTimeout, throwExceptionIfResponseNotReceived, loggingOptions);
         }
 
-        private void LogCommand(string commandName, JsonNode commandParameters, DevToolsCommandLoggingOptions loggingOptions = null)
+        protected virtual void LogCommand(string commandName, JsonNode commandParameters, DevToolsCommandLoggingOptions loggingOptions = null)
         {
             var logging = (loggingOptions ?? new DevToolsCommandLoggingOptions()).Command;
             if (!logging.Enabled)
@@ -183,7 +183,7 @@ namespace Aquality.Selenium.Browsers
             }
         }
 
-        private void LogCommandResult(JsonNode result, DevToolsCommandLoggingOptions loggingOptions = null)
+        protected virtual void LogCommandResult(JsonNode result, DevToolsCommandLoggingOptions loggingOptions = null)
         {
             var logging = (loggingOptions ?? new DevToolsCommandLoggingOptions()).Result;
             if (IsNotEmpty(result) && logging.Enabled)

--- a/Aquality.Selenium/src/Aquality.Selenium/Browsers/DevToolsHandling.cs
+++ b/Aquality.Selenium/src/Aquality.Selenium/Browsers/DevToolsHandling.cs
@@ -1,6 +1,5 @@
 ﻿using Aquality.Selenium.Core.Localization;
 using Aquality.Selenium.Logging;
-using Newtonsoft.Json.Linq;
 using OpenQA.Selenium;
 using OpenQA.Selenium.Chromium;
 using OpenQA.Selenium.DevTools;
@@ -8,6 +7,8 @@ using OpenQA.Selenium.Firefox;
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Text.Json;
+using System.Text.Json.Nodes;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -114,9 +115,9 @@ namespace Aquality.Selenium.Browsers
         {
             if (devToolsProvider is ChromiumDriver driver)
             {
-                LogCommand(commandName, JToken.FromObject(commandParameters), loggingOptions);
+                LogCommand(commandName, JsonSerializer.SerializeToNode(commandParameters), loggingOptions);
                 var result = driver.ExecuteCdpCommand(commandName, commandParameters);
-                var formattedResult = JToken.FromObject(result);
+                var formattedResult = JsonSerializer.SerializeToNode(result);
                 LogCommandResult(formattedResult, loggingOptions);
                 return result;
             }
@@ -130,17 +131,17 @@ namespace Aquality.Selenium.Browsers
         /// Sends the specified command and returns the associated command response.
         /// </summary>
         /// <param name="commandName">The name of the command to send.</param>
-        /// <param name="commandParameters">The parameters of the command as a JToken object.</param>
+        /// <param name="commandParameters">The parameters of the command as a JsonNode object.</param>
         /// <param name="cancellationToken">A CancellationToken object to allow for cancellation of the command.</param>
         /// <param name="millisecondsTimeout">The execution timeout of the command in milliseconds.</param>
         /// <param name="throwExceptionIfResponseNotReceived"><see langword="true"/> to throw an exception if a response is not received; otherwise, <see langword="false"/>.</param>
         /// <param name="loggingOptions">Logging preferences.</param>
-        /// <returns>A JToken based on a command created with the specified command name and parameters.</returns>
-        public async Task<JToken> SendCommand(string commandName, JToken commandParameters = null, 
+        /// <returns>A JsonNode based on a command created with the specified command name and parameters.</returns>
+        public async Task<JsonNode> SendCommand(string commandName, JsonNode commandParameters = null, 
             CancellationToken cancellationToken = default, int? millisecondsTimeout = null, bool throwExceptionIfResponseNotReceived = true, 
             DevToolsCommandLoggingOptions loggingOptions = null)
         {
-            var parameters = commandParameters ?? new JObject();
+            var parameters = commandParameters ?? new JsonObject();
             LogCommand(commandName, parameters, loggingOptions);
             var result = await devToolsProvider.GetDevToolsSession()
                 .SendCommand(commandName, parameters, cancellationToken, millisecondsTimeout, throwExceptionIfResponseNotReceived);
@@ -156,23 +157,23 @@ namespace Aquality.Selenium.Browsers
         /// <param name="millisecondsTimeout">The execution timeout of the command in milliseconds.</param>
         /// <param name="throwExceptionIfResponseNotReceived"><see langword="true"/> to throw an exception if a response is not received; otherwise, <see langword="false"/>.</param>
         /// <param name="loggingOptions">Logging preferences.</param>
-        /// <returns>A JToken based on a command created with the specified command name and parameters.</returns>
-        public async Task<JToken> SendCommand(ICommand commandWithParameters,
+        /// <returns>A JsonNode based on a command created with the specified command name and parameters.</returns>
+        public async Task<JsonNode> SendCommand(ICommand commandWithParameters,
             CancellationToken cancellationToken = default, int? millisecondsTimeout = null, bool throwExceptionIfResponseNotReceived = true, 
             DevToolsCommandLoggingOptions loggingOptions = null)
         {
-            return await SendCommand(commandWithParameters.CommandName, JToken.FromObject(commandWithParameters), 
+            return await SendCommand(commandWithParameters.CommandName, JsonSerializer.SerializeToNode(commandWithParameters, commandWithParameters.GetType()), 
                 cancellationToken, millisecondsTimeout, throwExceptionIfResponseNotReceived, loggingOptions);
         }
 
-        private void LogCommand(string commandName, JToken commandParameters, DevToolsCommandLoggingOptions loggingOptions = null)
+        private void LogCommand(string commandName, JsonNode commandParameters, DevToolsCommandLoggingOptions loggingOptions = null)
         {
             var logging = (loggingOptions ?? new DevToolsCommandLoggingOptions()).Command;
             if (!logging.Enabled)
             {
                 return;
             }
-            if (commandParameters.Any())
+            if (IsNotEmpty(commandParameters))
             {
                 Logger.LogByLevel(logging.LogLevel, "loc.browser.devtools.command.execute.withparams", commandName, commandParameters.ToString());
             }
@@ -182,13 +183,18 @@ namespace Aquality.Selenium.Browsers
             }
         }
 
-        private void LogCommandResult(JToken result, DevToolsCommandLoggingOptions loggingOptions = null)
+        private void LogCommandResult(JsonNode result, DevToolsCommandLoggingOptions loggingOptions = null)
         {
             var logging = (loggingOptions ?? new DevToolsCommandLoggingOptions()).Result;
-            if (result.Any() && logging.Enabled)
+            if (IsNotEmpty(result) && logging.Enabled)
             {
                 Logger.LogByLevel(logging.LogLevel, "loc.browser.devtools.command.execute.result", result.ToString());
             }
+        }
+
+        private bool IsNotEmpty(JsonNode jsonNode)
+        {
+            return jsonNode is JsonArray array ? array.Any() : (jsonNode as JsonObject).Any();
         }
     }
 }

--- a/Aquality.Selenium/src/Aquality.Selenium/Browsers/DevToolsPerformanceExtensions.cs
+++ b/Aquality.Selenium/src/Aquality.Selenium/Browsers/DevToolsPerformanceExtensions.cs
@@ -18,7 +18,7 @@ namespace Aquality.Selenium.Browsers
         /// </summary>
         /// <param name="devTools">Current instance of <see cref="DevToolsHandling"/>.</param>
         /// <returns>A task for asynchronous command.</returns>
-        public static async Task DisablePerfomanceMonitoring(this DevToolsHandling devTools)
+        public static async Task DisablePerformanceMonitoring(this DevToolsHandling devTools)
         {
             await devTools.SendCommand(new DisableCommandSettings());
         }
@@ -30,7 +30,7 @@ namespace Aquality.Selenium.Browsers
         /// <param name="timeDomain">Time domain to use for collecting and reporting duration metrics.
         /// Allowed Values: timeTicks, threadTicks. </param>
         /// <returns>A task for asynchronous command.</returns>
-        public static async Task EnablePerfomanceMonitoring(this DevToolsHandling devTools, string timeDomain = null)
+        public static async Task EnablePerformanceMonitoring(this DevToolsHandling devTools, string timeDomain = null)
         {
             await devTools.SendCommand(new EnableCommandSettings { TimeDomain = timeDomain });
         }

--- a/Aquality.Selenium/src/Aquality.Selenium/Browsers/DevToolsPerformanceExtensions.cs
+++ b/Aquality.Selenium/src/Aquality.Selenium/Browsers/DevToolsPerformanceExtensions.cs
@@ -3,6 +3,7 @@ using OpenQA.Selenium.DevTools.V85.Performance;
 using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
+using System.Text.Json.Nodes;
 using System.Threading.Tasks;
 
 namespace Aquality.Selenium.Browsers
@@ -42,8 +43,8 @@ namespace Aquality.Selenium.Browsers
         /// <returns>A task for asynchronous command with current values for run-time metrics as result.</returns>
         public static async Task<IDictionary<string, double>> GetPerformanceMetrics(this DevToolsHandling devTools)
         {
-            JToken result = await devTools.SendCommand(new GetMetricsCommandSettings());
-            return (result["metrics"] as JArray)
+            JsonNode result = await devTools.SendCommand(new GetMetricsCommandSettings());
+            return (result["metrics"].AsArray())
                 .ToDictionary(item => item["name"].ToString(), item => double.Parse(item["value"].ToString(), CultureInfo.InvariantCulture));
         }
     }

--- a/Aquality.Selenium/src/Aquality.Selenium/Browsers/DevToolsPerformanceExtensions.cs
+++ b/Aquality.Selenium/src/Aquality.Selenium/Browsers/DevToolsPerformanceExtensions.cs
@@ -1,5 +1,4 @@
-﻿using Newtonsoft.Json.Linq;
-using OpenQA.Selenium.DevTools.V85.Performance;
+﻿using OpenQA.Selenium.DevTools.V85.Performance;
 using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;

--- a/Aquality.Selenium/src/Aquality.Selenium/Browsers/JavaScriptHandling.cs
+++ b/Aquality.Selenium/src/Aquality.Selenium/Browsers/JavaScriptHandling.cs
@@ -23,7 +23,7 @@ namespace Aquality.Selenium.Browsers
             javaScriptEngine = new JavaScriptEngine(driver);
         }
 
-        private ILocalizedLogger Logger => AqualityServices.LocalizedLogger;
+        private static ILocalizedLogger Logger => AqualityServices.LocalizedLogger;
 
         /// <summary>
         /// Gets the read-only list of initialization scripts added for this JavaScript engine.

--- a/Aquality.Selenium/src/Aquality.Selenium/Browsers/NetworkHandling.cs
+++ b/Aquality.Selenium/src/Aquality.Selenium/Browsers/NetworkHandling.cs
@@ -21,7 +21,7 @@ namespace Aquality.Selenium.Browsers
             network = driver.Manage().Network;
         }
 
-        private ILocalizedLogger Logger => AqualityServices.LocalizedLogger;
+        private static ILocalizedLogger Logger => AqualityServices.LocalizedLogger;
 
         /// <summary>
         /// A network request sent event.

--- a/Aquality.Selenium/src/Aquality.Selenium/Configurations/WebDriverSettings/DriverSettings.cs
+++ b/Aquality.Selenium/src/Aquality.Selenium/Configurations/WebDriverSettings/DriverSettings.cs
@@ -215,14 +215,14 @@ namespace Aquality.Selenium.Configurations.WebDriverSettings
             optionProperty.SetValue(options, valueToSet);
         }
 
-        private object ParseEnumValue(Type propertyType, object optionValue)
+        private static object ParseEnumValue(Type propertyType, object optionValue)
         {
             return optionValue is string
                 ? Enum.Parse(propertyType, optionValue.ToString(), ignoreCase: true)
                 : Enum.ToObject(propertyType, Convert.ChangeType(optionValue, Enum.GetUnderlyingType(propertyType)));
         }
 
-        private bool IsEnumValue(Type propertyType, object optionValue)
+        private static bool IsEnumValue(Type propertyType, object optionValue)
         {
             var valueAsString = optionValue.ToString();
             if (!propertyType.IsEnum || string.IsNullOrEmpty(valueAsString))

--- a/Aquality.Selenium/src/Aquality.Selenium/Configurations/WebDriverSettings/DriverSettings.cs
+++ b/Aquality.Selenium/src/Aquality.Selenium/Configurations/WebDriverSettings/DriverSettings.cs
@@ -201,7 +201,7 @@ namespace Aquality.Selenium.Configurations.WebDriverSettings
             }
         }
 
-        private void SetOptionByPropertyName(DriverOptions options, KeyValuePair<string, object> option, Exception exception)
+        private static void SetOptionByPropertyName(DriverOptions options, KeyValuePair<string, object> option, Exception exception)
         {
             var optionProperty = options
                             .GetType()

--- a/Aquality.Selenium/src/Aquality.Selenium/Configurations/WebDriverSettings/DriverSettings.cs
+++ b/Aquality.Selenium/src/Aquality.Selenium/Configurations/WebDriverSettings/DriverSettings.cs
@@ -237,7 +237,7 @@ namespace Aquality.Selenium.Configurations.WebDriverSettings
                     && propertyType.IsEnumDefined(Convert.ChangeType(optionValue, Enum.GetUnderlyingType(propertyType))));
         }
 
-        private bool IsValueOfIntegralNumericType(object value)
+        private static bool IsValueOfIntegralNumericType(object value)
         {
             return value is byte || value is sbyte
                 || value is ushort || value is short
@@ -245,7 +245,7 @@ namespace Aquality.Selenium.Configurations.WebDriverSettings
                 || value is ulong || value is long;
         }
 
-        private bool IsPropertyNameMatchOption(string propertyName, string optionKey)
+        private static bool IsPropertyNameMatchOption(string propertyName, string optionKey)
         {
             return propertyName.Equals(optionKey, StringComparison.InvariantCultureIgnoreCase)
                 || optionKey.ToLowerInvariant().Contains(propertyName.ToLowerInvariant());

--- a/Aquality.Selenium/src/Aquality.Selenium/Elements/Actions/JsActions.cs
+++ b/Aquality.Selenium/src/Aquality.Selenium/Elements/Actions/JsActions.cs
@@ -29,9 +29,9 @@ namespace Aquality.Selenium.Elements.Actions
             Logger = logger;
         }
 
-        private Browser Browser => AqualityServices.Browser;
+        private static Browser Browser => AqualityServices.Browser;
 
-        private IElementActionRetrier ActionRetrier => AqualityServices.Get<IElementActionRetrier>();
+        private static IElementActionRetrier ActionRetrier => AqualityServices.Get<IElementActionRetrier>();
 
         protected ILocalizedLogger Logger { get; }
 

--- a/Aquality.Selenium/src/Aquality.Selenium/Elements/Actions/MouseActions.cs
+++ b/Aquality.Selenium/src/Aquality.Selenium/Elements/Actions/MouseActions.cs
@@ -113,7 +113,7 @@ namespace Aquality.Selenium.Elements.Actions
                     .MoveToElement(element, -element.Size.Width / 2, -element.Size.Height / 2)));
         }
 
-        private SeleniumActions MoveToElement(IWebElement element)
+        private static SeleniumActions MoveToElement(IWebElement element)
         {
             return new SeleniumActions(AqualityServices.Browser.Driver).MoveToElement(element);
         }

--- a/Aquality.Selenium/src/Aquality.Selenium/Elements/Element.cs
+++ b/Aquality.Selenium/src/Aquality.Selenium/Elements/Element.cs
@@ -30,7 +30,7 @@ namespace Aquality.Selenium.Elements
 
         public override ICoreElementStateProvider State => new ElementStateProvider(Locator, ConditionalWait, Finder, LogElementState);
 
-        protected IBrowserProfile BrowserProfile => AqualityServices.Get<IBrowserProfile>();
+        protected virtual IBrowserProfile BrowserProfile => AqualityServices.Get<IBrowserProfile>();
 
         public JsActions JsActions => new JsActions(this, ElementType, LocalizedLogger, BrowserProfile);
 

--- a/Aquality.Selenium/src/Aquality.Selenium/Elements/Interfaces/ITextBox.cs
+++ b/Aquality.Selenium/src/Aquality.Selenium/Elements/Interfaces/ITextBox.cs
@@ -12,6 +12,11 @@
         string Value { get; }
 
         /// <summary>
+        /// Clear element text.
+        /// </summary>
+        void Clear();
+
+        /// <summary>
         /// Type text in an element.
         /// </summary>
         /// <param name="value">Text to type.</param>

--- a/Aquality.Selenium/src/Aquality.Selenium/Elements/TextBox.cs
+++ b/Aquality.Selenium/src/Aquality.Selenium/Elements/TextBox.cs
@@ -19,6 +19,13 @@ namespace Aquality.Selenium.Elements
 
         public string Value => GetAttribute(Attributes.Value);
 
+        public void Clear()
+        {
+            LogElementAction("loc.text.clearing");
+            JsActions.HighlightElement();
+            DoWithRetry(() => GetElement().Clear());
+        }
+
         public void Type(string value, bool secret = false)
         {
             LogElementAction("loc.text.typing", secret ? SecretMask : value);

--- a/Aquality.Selenium/tests/Aquality.Selenium.Tests/Aquality.Selenium.Tests.csproj
+++ b/Aquality.Selenium/tests/Aquality.Selenium.Tests/Aquality.Selenium.Tests.csproj
@@ -29,12 +29,12 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="nunit" Version="4.1.0" />
+    <PackageReference Include="nunit" Version="4.2.2" />
     <PackageReference Include="NUnit3TestAdapter" Version="4.6.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.10.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Aquality.Selenium/tests/Aquality.Selenium.Tests/Integration/DevToolsEmulationTests.cs
+++ b/Aquality.Selenium/tests/Aquality.Selenium.Tests/Integration/DevToolsEmulationTests.cs
@@ -59,11 +59,11 @@ namespace Aquality.Selenium.Tests.Integration
         {
             void setAction(long width, long height, bool isMobile, double scaleFactor)
             {
-                var parameters = new OpenQA.Selenium.DevTools.V127.Emulation.SetDeviceMetricsOverrideCommandSettings
+                var parameters = new OpenQA.Selenium.DevTools.V128.Emulation.SetDeviceMetricsOverrideCommandSettings
                 {
-                    DisplayFeature = new OpenQA.Selenium.DevTools.V127.Emulation.DisplayFeature
+                    DisplayFeature = new OpenQA.Selenium.DevTools.V128.Emulation.DisplayFeature
                     {
-                        Orientation = OpenQA.Selenium.DevTools.V127.Emulation.DisplayFeatureOrientationValues.Horizontal
+                        Orientation = OpenQA.Selenium.DevTools.V128.Emulation.DisplayFeatureOrientationValues.Horizontal
                     },
                     Width = width,
                     Height = height,

--- a/Aquality.Selenium/tests/Aquality.Selenium.Tests/Integration/DevToolsPerformanceTests.cs
+++ b/Aquality.Selenium/tests/Aquality.Selenium.Tests/Integration/DevToolsPerformanceTests.cs
@@ -11,7 +11,7 @@ namespace Aquality.Selenium.Tests.Integration
         [Test]
         public void Should_BePossibleTo_CollectPerformanceMetrics()
         {
-            Assert.DoesNotThrowAsync(async () => await DevTools.EnablePerfomanceMonitoring(), "Should be possible to enable performance monitoring");
+            Assert.DoesNotThrowAsync(async () => await DevTools.EnablePerformanceMonitoring(), "Should be possible to enable performance monitoring");
 
             AqualityServices.Browser.GoTo("http://www.google.com");
             IDictionary<string, double> metrics = null;
@@ -22,7 +22,7 @@ namespace Aquality.Selenium.Tests.Integration
             IDictionary<string, double> otherMetrics = DevTools.GetPerformanceMetrics().GetAwaiter().GetResult();
             Assert.That(otherMetrics, Is.Not.EqualTo(metrics), "Some additional metrics should have been collected");
 
-            Assert.DoesNotThrowAsync(async () => await DevTools.DisablePerfomanceMonitoring(), "Should be possible to disable performance monitoring");
+            Assert.DoesNotThrowAsync(async () => await DevTools.DisablePerformanceMonitoring(), "Should be possible to disable performance monitoring");
             AqualityServices.Browser.Refresh();
             metrics = DevTools.GetPerformanceMetrics().GetAwaiter().GetResult();
             Assert.That(metrics, Is.Empty, "Metrics should have not been collected after performance monitoring have been disabled");

--- a/Aquality.Selenium/tests/Aquality.Selenium.Tests/Integration/Elements/TextBoxTests.cs
+++ b/Aquality.Selenium/tests/Aquality.Selenium.Tests/Integration/Elements/TextBoxTests.cs
@@ -28,6 +28,33 @@ namespace Aquality.Selenium.Tests.Integration.Elements
         }
 
         [Test]
+        public void Should_BePossibleTo_Clear_WhenWasEmpty()
+        {
+            var usernameTxb = authForm.UserNameTextBox;
+            usernameTxb.Clear();
+            Assert.That(usernameTxb.Value, Is.Empty);
+        }
+
+        [Test]
+        public void Should_BePossibleTo_Clear_WhenWasFilled()
+        {
+            var initialText = "initial value";
+            var usernameTxb = authForm.UserNameTextBox;
+            usernameTxb.Type(initialText);
+            usernameTxb.Clear();
+            Assert.That(usernameTxb.Value, Is.Empty);
+        }
+
+        [Test]
+        public void Should_BePossibleTo_Clear_Twice()
+        {
+            var usernameTxb = authForm.UserNameTextBox;
+            usernameTxb.Clear();
+            usernameTxb.Clear();
+            Assert.That(usernameTxb.Value, Is.Empty);
+        }
+
+        [Test]
         public void Should_BePossibleTo_ClearAndType()
         {
             var initialText = "initial value";

--- a/Aquality.Selenium/tests/Aquality.Selenium.Tests/Resources/settings.json
+++ b/Aquality.Selenium/tests/Aquality.Selenium.Tests/Resources/settings.json
@@ -25,7 +25,7 @@
           "Performance": "All"
       },
       "excludedArguments": [ "enable-automation" ],
-      "startArguments": [],
+      "startArguments": [ "--disable-search-engine-choice-screen" ],
       "pageLoadStrategy": "Normal"
     },
     "firefox": {


### PR DESCRIPTION
Use System.Text.Json instead of Newtonsoft.Json for DevToolsHandlong Update tests, use --disable-search-engine-choice-screen in tests Add Clear method to ITextBox interface
Use new FindElements logic from Aquality.Selenium.Core to avoid possible StaleElementReference while iterating WebElements list to fix #260