### PR TITLE
Update to Selenium 4.31.0 +semver:feature

### DIFF
--- a/Aquality.Selenium/src/Aquality.Selenium.Images/Aquality.Selenium.Images.csproj
+++ b/Aquality.Selenium/src/Aquality.Selenium.Images/Aquality.Selenium.Images.csproj
@@ -14,7 +14,7 @@
 	  <PackageTags>selenium webdriver browser automation image locator</PackageTags>
 	  <PackageLicenseFile>LICENSE</PackageLicenseFile>
 	  <PackageReadmeFile>README.md</PackageReadmeFile>
-	  <Copyright>Copyright 2024 Aquality Automation</Copyright>
+	  <Copyright>Copyright 2025 Aquality Automation</Copyright>
 	  <IsPackable>true</IsPackable>
   </PropertyGroup>
 

--- a/Aquality.Selenium/src/Aquality.Selenium/Aquality.Selenium.csproj
+++ b/Aquality.Selenium/src/Aquality.Selenium/Aquality.Selenium.csproj
@@ -15,7 +15,7 @@
     <PackageTags>selenium webdriver browser automation</PackageTags>
     <PackageLicenseFile>LICENSE</PackageLicenseFile>
 	<PackageReadmeFile>README.md</PackageReadmeFile>
-    <Copyright>Copyright 2024 Aquality Automation</Copyright>
+    <Copyright>Copyright 2025 Aquality Automation</Copyright>
     <IsPackable>true</IsPackable>
   </PropertyGroup>
 
@@ -91,8 +91,8 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Aquality.Selenium.Core" Version="3.1.3" />
-    <PackageReference Include="WebDriverManager" Version="2.17.4" />
+    <PackageReference Include="Aquality.Selenium.Core" Version="3.2.1" />
+    <PackageReference Include="WebDriverManager" Version="2.17.5" />
   </ItemGroup>
 
 </Project>

--- a/Aquality.Selenium/src/Aquality.Selenium/Aquality.Selenium.xml
+++ b/Aquality.Selenium/src/Aquality.Selenium/Aquality.Selenium.xml
@@ -478,7 +478,7 @@
             </summary>
             <param name="devTools">Current instance of <see cref="T:Aquality.Selenium.Browsers.DevToolsHandling"/>.</param>
             <param name="commandParameters">Version-specific set of parameters. 
-            For example, take a look at <see cref="T:OpenQA.Selenium.DevTools.V85.Emulation.SetDeviceMetricsOverrideCommandSettings"/>.</param>
+            For example, take a look at <see cref="T:OpenQA.Selenium.DevTools.V135.Emulation.SetDeviceMetricsOverrideCommandSettings"/>.</param>
             <returns>A task for asynchronous command.</returns>
         </member>
         <member name="M:Aquality.Selenium.Browsers.DevToolsEmulationExtensions.SetDeviceMetricsOverride(Aquality.Selenium.Browsers.DevToolsHandling,System.Int64,System.Int64,System.Boolean,System.Double,System.String,System.Nullable{System.Int32})">
@@ -508,7 +508,7 @@
             </summary>
             <param name="devTools">Current instance of <see cref="T:Aquality.Selenium.Browsers.DevToolsHandling"/>.</param>
             <param name="commandParameters">Version-specific set of parameters. 
-            For example, take a look at <see cref="T:OpenQA.Selenium.DevTools.V85.Emulation.SetUserAgentOverrideCommandSettings"/>.</param>
+            For example, take a look at <see cref="T:OpenQA.Selenium.DevTools.V135.Emulation.SetUserAgentOverrideCommandSettings"/>.</param>
             <returns>A task for asynchronous command.</returns>
         </member>
         <member name="M:Aquality.Selenium.Browsers.DevToolsEmulationExtensions.SetUserAgentOverride(Aquality.Selenium.Browsers.DevToolsHandling,System.String,System.String,System.String)">
@@ -544,7 +544,7 @@
             </summary>
             <param name="devTools">Current instance of <see cref="T:Aquality.Selenium.Browsers.DevToolsHandling"/>.</param>
             <param name="commandParameters">Version-specific set of parameters. 
-            For example, take a look at <see cref="T:OpenQA.Selenium.DevTools.V85.Emulation.SetTouchEmulationEnabledCommandSettings"/>.</param>
+            For example, take a look at <see cref="T:OpenQA.Selenium.DevTools.V135.Emulation.SetTouchEmulationEnabledCommandSettings"/>.</param>
             <returns>A task for asynchronous command.</returns>
         </member>
         <member name="M:Aquality.Selenium.Browsers.DevToolsEmulationExtensions.SetEmulatedMedia(Aquality.Selenium.Browsers.DevToolsHandling,System.String,System.Collections.Generic.IDictionary{System.String,System.String})">
@@ -563,7 +563,7 @@
             </summary>
             <param name="devTools">Current instance of <see cref="T:Aquality.Selenium.Browsers.DevToolsHandling"/>.</param>
             <param name="commandParameters">Version-specific set of parameters. 
-            For example, take a look at <see cref="T:OpenQA.Selenium.DevTools.V85.Emulation.SetEmulatedMediaCommandSettings"/>.</param>
+            For example, take a look at <see cref="T:OpenQA.Selenium.DevTools.V135.Emulation.SetEmulatedMediaCommandSettings"/>.</param>
             <returns>A task for asynchronous command.</returns>
         </member>
         <member name="M:Aquality.Selenium.Browsers.DevToolsEmulationExtensions.DisableEmulatedMediaOverride(Aquality.Selenium.Browsers.DevToolsHandling)">
@@ -658,7 +658,7 @@
             <param name="millisecondsTimeout">The execution timeout of the command in milliseconds.</param>
             <param name="throwExceptionIfResponseNotReceived"><see langword="true"/> to throw an exception if a response is not received; otherwise, <see langword="false"/>.</param>
             <param name="loggingOptions">Logging preferences.</param>
-            <returns>A JsonNode based on a command created with the specified command name and parameters.</returns>
+            <returns>A JsonElement? based on a command created with the specified command name and parameters.</returns>
         </member>
         <member name="M:Aquality.Selenium.Browsers.DevToolsHandling.SendCommand(OpenQA.Selenium.DevTools.ICommand,System.Threading.CancellationToken,System.Nullable{System.Int32},System.Boolean,Aquality.Selenium.Logging.DevToolsCommandLoggingOptions)">
             <summary>
@@ -669,7 +669,7 @@
             <param name="millisecondsTimeout">The execution timeout of the command in milliseconds.</param>
             <param name="throwExceptionIfResponseNotReceived"><see langword="true"/> to throw an exception if a response is not received; otherwise, <see langword="false"/>.</param>
             <param name="loggingOptions">Logging preferences.</param>
-            <returns>A JsonNode based on a command created with the specified command name and parameters.</returns>
+            <returns>A JsonElement? based on a command created with the specified command name and parameters.</returns>
         </member>
         <member name="T:Aquality.Selenium.Browsers.DevToolsPerformanceExtensions">
             <summary>

--- a/Aquality.Selenium/src/Aquality.Selenium/Browsers/DevToolsEmulationExtensions.cs
+++ b/Aquality.Selenium/src/Aquality.Selenium/Browsers/DevToolsEmulationExtensions.cs
@@ -1,10 +1,11 @@
 ﻿using Aquality.Selenium.Core.Utilities;
 using OpenQA.Selenium.DevTools;
-using OpenQA.Selenium.DevTools.V85.DOM;
-using OpenQA.Selenium.DevTools.V85.Emulation;
+using OpenQA.Selenium.DevTools.V135.DOM;
+using OpenQA.Selenium.DevTools.V135.Emulation;
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Text.Json;
 using System.Threading.Tasks;
 
 namespace Aquality.Selenium.Browsers
@@ -24,7 +25,10 @@ namespace Aquality.Selenium.Browsers
         public static async Task<bool> CanEmulate(this DevToolsHandling devTools)
         {
             var response = await devTools.SendCommand(new CanEmulateCommandSettings());
-            return response["result"]?.ToString().Equals(bool.TrueString, StringComparison.OrdinalIgnoreCase) == true;
+            return response.HasValue && response.Value.TryGetProperty("result", out JsonElement resultElement)
+                && (resultElement.ValueKind == JsonValueKind.True ||
+                (resultElement.ValueKind == JsonValueKind.String &&
+                resultElement.GetString().Equals(bool.TrueString, StringComparison.OrdinalIgnoreCase)));
         }
 
         /// <summary>

--- a/Aquality.Selenium/src/Aquality.Selenium/Browsers/DevToolsPerformanceExtensions.cs
+++ b/Aquality.Selenium/src/Aquality.Selenium/Browsers/DevToolsPerformanceExtensions.cs
@@ -1,8 +1,8 @@
-﻿using OpenQA.Selenium.DevTools.V85.Performance;
+﻿using OpenQA.Selenium.DevTools.V135.Performance;
 using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
-using System.Text.Json.Nodes;
+using System.Text.Json;
 using System.Threading.Tasks;
 
 namespace Aquality.Selenium.Browsers
@@ -42,9 +42,9 @@ namespace Aquality.Selenium.Browsers
         /// <returns>A task for asynchronous command with current values for run-time metrics as result.</returns>
         public static async Task<IDictionary<string, double>> GetPerformanceMetrics(this DevToolsHandling devTools)
         {
-            JsonNode result = await devTools.SendCommand(new GetMetricsCommandSettings());
-            return (result["metrics"].AsArray())
-                .ToDictionary(item => item["name"].ToString(), item => double.Parse(item["value"].ToString(), CultureInfo.InvariantCulture));
+            JsonElement? result = await devTools.SendCommand(new GetMetricsCommandSettings());
+            return (result.Value.GetProperty("metrics").EnumerateArray())
+                .ToDictionary(item => item.GetProperty("name").ToString(), item => double.Parse(item.GetProperty("value").ToString(), CultureInfo.InvariantCulture));
         }
     }
 }

--- a/Aquality.Selenium/tests/Aquality.Selenium.Tests/Aquality.Selenium.Tests.csproj
+++ b/Aquality.Selenium/tests/Aquality.Selenium.Tests/Aquality.Selenium.Tests.csproj
@@ -29,12 +29,12 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="nunit" Version="4.2.2" />
-    <PackageReference Include="NUnit3TestAdapter" Version="4.6.0">
+    <PackageReference Include="nunit" Version="4.3.2" />
+    <PackageReference Include="NUnit3TestAdapter" Version="5.0.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.13.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Aquality.Selenium/tests/Aquality.Selenium.Tests/Integration/DevToolsEmulationTests.cs
+++ b/Aquality.Selenium/tests/Aquality.Selenium.Tests/Integration/DevToolsEmulationTests.cs
@@ -5,7 +5,7 @@ using Aquality.Selenium.Tests.Integration.TestApp.MyLocation;
 using Aquality.Selenium.Tests.Integration.TestApp.TheInternet.Forms;
 using NUnit.Framework;
 using OpenQA.Selenium;
-using OpenQA.Selenium.DevTools.V85.Emulation;
+using OpenQA.Selenium.DevTools.V135.Emulation;
 using System;
 using System.Collections.Generic;
 
@@ -59,11 +59,11 @@ namespace Aquality.Selenium.Tests.Integration
         {
             void setAction(long width, long height, bool isMobile, double scaleFactor)
             {
-                var parameters = new OpenQA.Selenium.DevTools.V131.Emulation.SetDeviceMetricsOverrideCommandSettings
+                var parameters = new OpenQA.Selenium.DevTools.V134.Emulation.SetDeviceMetricsOverrideCommandSettings
                 {
-                    DisplayFeature = new OpenQA.Selenium.DevTools.V131.Emulation.DisplayFeature
+                    DisplayFeature = new OpenQA.Selenium.DevTools.V134.Emulation.DisplayFeature
                     {
-                        Orientation = OpenQA.Selenium.DevTools.V131.Emulation.DisplayFeatureOrientationValues.Horizontal
+                        Orientation = OpenQA.Selenium.DevTools.V134.Emulation.DisplayFeatureOrientationValues.Horizontal
                     },
                     Width = width,
                     Height = height,

--- a/LICENSE
+++ b/LICENSE
@@ -186,7 +186,7 @@
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright 2024 Aquality Automation
+   Copyright 2025 Aquality Automation
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -12,37 +12,34 @@ stages:
 
   jobs:
   - job: sonar
-    displayName: Analyse code with SonarQube
+    displayName: Analyze code with SonarQube
 
     steps:
-    - task: SonarCloudPrepare@2
+    - task: SonarCloudPrepare@3
       displayName: 'Prepare SonarCloud analysis'
       inputs:
         SonarCloud: 'SonarCloud'
         organization: 'aqualityautomation'
-        scannerMode: 'MSBuild'
+        scannerMode: 'dotnet'
         projectKey: 'aquality-automation_aquality-selenium-dotnet'
         projectName: 'aquality-selenium-dotnet'
         projectVersion: '$(Build.BuildNumber)'
-        extraProperties: |
-          sonar.coverage.exclusions=**/**
+        extraProperties: 'sonar.coverage.exclusions=**/**'
           
     - task: DotNetCoreCLI@2
       displayName: 'Build solution'
-      env: 
-        MSBUILDSINGLELOADCONTEXT: 1  # https://github.com/SpecFlowOSS/SpecFlow/issues/1912
       inputs:
         command: 'build'
         projects: Aquality.Selenium/Aquality.Selenium.sln
         arguments: -c $(buildConfiguration)      
 
-    - task: SonarCloudAnalyze@2
-      displayName: 'Run SonarCloud code analysis'
-      continueOnError: true
+    - task: SonarCloudAnalyze@3
       inputs:
         jdkversion: 'JAVA_HOME_17_X64'
+      displayName: 'Run SonarCloud code analysis'
+      continueOnError: true
 
-    - task: SonarCloudPublish@2
+    - task: SonarCloudPublish@3
       displayName: 'Publish SonarCloud quality gate results'
       inputs:
         pollingTimeoutSec: '300'
@@ -83,16 +80,18 @@ stages:
     - script: dotnet pack Aquality.Selenium\Aquality.Selenium.sln -c $(buildConfiguration) -p:Version=$(GitVersion.NuGetVersion) -o $(Build.ArtifactStagingDirectory)
       displayName: 'Pack to NuGet package'
 
-    - task: GitHubRelease@0
+    - task: GitHubRelease@1
       displayName: 'Create tag on GitHub'
       inputs:
         gitHubConnection: 'github.com_aqualityautomation'
         repositoryName: 'aquality-automation/aquality-selenium-dotnet'
         action: 'create'
+        target: '$(Build.SourceVersion)'
+        tagSource: 'userSpecifiedTag'
         tag: 'v$(GitVersion.NuGetVersion)'
-        title: 'v$(GitVersion.NuGetVersion)'
-        tagSource: 'manual'
-        isPreRelease: contains(variables['GitVersion.NuGetVersion'], '-')
+        isDraft: contains(variables['GitVersion.NuGetVersion'], '-')
+        changeLogCompareToRelease: 'lastFullRelease'
+        changeLogType: 'commitBased'
 
     - task: NuGetCommand@2
       displayName: 'Push NuGet package'


### PR DESCRIPTION
Update to Selenium 4.31.0
Update other package references
replace JsonNode with JsonElement? references
removed CDP V85 references as they are no longer supported by Firefox and Selenium 
Update tasks in azure-pipelines yml
update license year